### PR TITLE
fix: use REPO_PAT for version-tag to push to protected branch

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -93,6 +93,12 @@ gh pr merge <number> --rebase
 - **Trigger:** Push to `next`.
 - **Skips:** If the push is its own version-bump commit (avoids loop).
 - **Steps:** Generate version → `bun run version:sync <version>` → commit → tag → release.
+- **Requires:** `REPO_PAT` secret (PAT from repo admin) to push to protected `next`.
+
+**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Repository admin** to the bypass list, then:
+1. Create a PAT (classic `repo` or fine-grained Contents: Read and write) from a repo admin.
+2. Add as repo secret `REPO_PAT`.
+3. Workflow pushes as that user; admin bypass allows it.
 
 ### Deploy Next (`.github/workflows/deploy-next.yml`)
 

--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -30,19 +30,34 @@ No exclusions. Single source: the workflow generates the version and passes it t
 
 ```mermaid
 flowchart LR
-    PR[PR merged to next]
+    Branch[Branch from next]
+    Commit[Commit changes]
+    Push[Push branch]
+    AskPR{Ask user: create PR?}
+    CreatePR[gh pr create]
+    Merge[gh pr merge]
     VT[version-tag.yml]
-    Sync[Sync all packages]
+    Sync[Sync packages]
     Tag[Tag + Release]
     Deploy[deploy-next.yml]
-    PR --> VT --> Sync --> Tag
-    PR --> Deploy
+
+    Branch --> Commit --> Push --> AskPR
+    AskPR -->|Yes| CreatePR --> Merge
+    Merge --> VT --> Sync --> Tag
+    Merge --> Deploy
 ```
 
-1. PR passes checks and is merged to `next`.
-2. Push to `next` triggers `version-tag` and `deploy-next`.
-3. `version-tag`: Generate `YY.MMDD.HHMM`, sync to all packages, commit, tag, create GitHub release.
-4. `deploy-next`: Deploy maia and moai.
+**Developer flow:**
+1. Branch from `next`, make changes, commit, push.
+2. **Ask the user** if they want to create a PR. Only create when confirmed.
+3. `gh pr create` → open PR targeting `next`.
+4. **Ask the user** if they want to merge. Only merge when confirmed.
+5. `gh pr merge --rebase` → merge into `next`.
+
+**CI flow (after merge):**
+1. Push to `next` triggers `version-tag` and `deploy-next`.
+2. `version-tag`: Generate `YY.MMDD.HHMM`, sync all packages, commit, tag, create GitHub release.
+3. `deploy-next`: Deploy maia and moai.
 
 Version changes only on merge to `next`. No manual bumping.
 
@@ -54,6 +69,20 @@ The workflow skips when the head commit message contains `chore: bump version to
 
 - **`next`** – Deployment branch. Protected, updated only via PRs.
 - Feature branches – Branch from `next`, merge back via PR.
+
+---
+
+## PR Workflow (gh CLI)
+
+**Always ask the user** before creating or merging a PR. Never create or merge PRs without explicit confirmation.
+
+```bash
+# Create PR (after pushing branch)
+gh pr create --base next --head <branch> --title "<title>" --body "<body>"
+
+# Merge (rebase and merge)
+gh pr merge <number> --rebase
+```
 
 ---
 

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   version-tag:
     # Skip when this push was our own version-bump commit (avoids loop)
-    if: ${{ !contains(github.event.head_commit.message, 'chore: bump version to') }}
+    if: github.event.head_commit == null || contains(github.event.head_commit.message, 'chore: bump version to') == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_PAT }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -38,6 +38,8 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push and create release
+        env:
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Uses PAT instead of GITHUB_TOKEN so version-tag workflow can push to protected next. Add REPO_PAT secret (PAT from repo admin) and Repository admin to bypass list.