### PR TITLE
fix: use DEPLOY_KEY instead of REPO_PAT for version-tag

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -93,12 +93,13 @@ gh pr merge <number> --rebase
 - **Trigger:** Push to `next`.
 - **Skips:** If the push is its own version-bump commit (avoids loop).
 - **Steps:** Generate version → `bun run version:sync <version>` → commit → tag → release.
-- **Requires:** `REPO_PAT` secret (PAT from repo admin) to push to protected `next`.
+- **Requires:** `DEPLOY_KEY` secret (SSH private key) to push to protected `next`.
 
-**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Repository admin** to the bypass list, then:
-1. Create a PAT (classic `repo` or fine-grained Contents: Read and write) from a repo admin.
-2. Add as repo secret `REPO_PAT`.
-3. Workflow pushes as that user; admin bypass allows it.
+**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Deploy keys** to the bypass list, then:
+1. Generate SSH key: `ssh-keygen -t ed25519 -f ~/.ssh/maia_version_tag_deploy -N ""`
+2. Add **public** key to repo Settings → Deploy keys (allow write access).
+3. Add **private** key as repo secret `DEPLOY_KEY` (full content including BEGIN/END lines).
+4. Only the workflow (using this key) can push; no user bypass needed.
 
 ### Deploy Next (`.github/workflows/deploy-next.yml`)
 

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.REPO_PAT }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -38,8 +38,6 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push and create release
-        env:
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Switches from PAT to deploy key for pushing to protected next. Requires DEPLOY_KEY secret and Deploy keys in bypass list.