### PR TITLE
fix: add GH_TOKEN for gh release create, clarify deploy key bypass

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -95,7 +95,7 @@ gh pr merge <number> --rebase
 - **Steps:** Generate version → `bun run version:sync <version>` → commit → tag → release.
 - **Requires:** `DEPLOY_KEY` secret (SSH private key) to push to protected `next`.
 
-**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Deploy keys** to the bypass list, then:
+**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Deploy keys** to the bypass list for the ruleset that applies to `next`. Ensure Deploy keys bypasses **all** rules (including "Require pull request"), then:
 1. Generate SSH key: `ssh-keygen -t ed25519 -f ~/.ssh/maia_version_tag_deploy -N ""`
 2. Add **public** key to repo Settings → Deploy keys (allow write access).
 3. Add **private** key as repo secret `DEPLOY_KEY` (full content including BEGIN/END lines).

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -38,6 +38,8 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push and create release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Uses automatic github.token for gh CLI. Docs: deploy key must bypass all rules including Require PR.