### PR TITLE
fix: use release: commit message, deploy only on releases

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -61,7 +61,7 @@ flowchart LR
 
 Version changes only on merge to `next`. No manual bumping.
 
-The workflow skips when the head commit message contains `chore: bump version to`, so the version-bump push does not trigger another run (no loop).
+The version-tag workflow skips when the head commit message contains `release:`, so the release push does not trigger another run (no loop). Deploy-next runs only on `release:` commits (or manual trigger), so we deploy once per merge.
 
 ---
 
@@ -91,7 +91,7 @@ gh pr merge <number> --rebase
 ### Version Tag (`.github/workflows/version-tag.yml`)
 
 - **Trigger:** Push to `next`.
-- **Skips:** If the push is its own version-bump commit (avoids loop).
+- **Skips:** If the push is its own release commit (avoids loop).
 - **Steps:** Generate version → `bun run version:sync <version>` → commit → tag → release.
 - **Requires:** `DEPLOY_KEY` secret (SSH private key) to push to protected `next`.
 
@@ -103,7 +103,8 @@ gh pr merge <number> --rebase
 
 ### Deploy Next (`.github/workflows/deploy-next.yml`)
 
-- **Trigger:** Push to `next`.
+- **Trigger:** Push to `next`, or manual.
+- **Runs only on:** `release:` commits (version-tag push) or workflow_dispatch. Skips merge commits — deploy once per merge.
 - Deploys maia and moai to Fly.io (parallel).
 
 ---

--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -95,7 +95,7 @@ gh pr merge <number> --rebase
 - **Steps:** Generate version → `bun run version:sync <version>` → commit → tag → release.
 - **Requires:** `DEPLOY_KEY` secret (SSH private key) to push to protected `next`.
 
-**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Deploy keys** to the bypass list, then:
+**Protected branch setup:** GitHub Actions is not a bypass actor. Add **Deploy keys** to the bypass list for the ruleset that applies to `next`. Ensure Deploy keys bypasses **all** rules (including "Require pull request"), then:
 1. Generate SSH key: `ssh-keygen -t ed25519 -f ~/.ssh/maia_version_tag_deploy -N ""`
 2. Add **public** key to repo Settings → Deploy keys (allow write access).
 3. Add **private** key as repo secret `DEPLOY_KEY` (full content including BEGIN/END lines).

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   deploy-moai:
+    # Deploy only on release commits (version-tag push), or manual trigger
+    if: github.event_name == 'workflow_dispatch' || (github.event.head_commit != null && contains(github.event.head_commit.message, 'release:'))
     name: Deploy moai
     runs-on: ubuntu-latest
     env:
@@ -23,6 +25,8 @@ jobs:
         run: ./services/moai/deploy.sh
 
   deploy-maia:
+    # Deploy only on release commits (version-tag push), or manual trigger
+    if: github.event_name == 'workflow_dispatch' || (github.event.head_commit != null && contains(github.event.head_commit.message, 'release:'))
     name: Deploy maia
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -38,6 +38,8 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push and create release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   version-tag:
-    # Skip when this push was our own version-bump commit (avoids loop)
-    if: "github.event.head_commit == null || contains(github.event.head_commit.message, 'chore: bump version to') == false"
+    # Skip when this push was our own release commit (avoids loop)
+    if: "github.event.head_commit == null || contains(github.event.head_commit.message, 'release:') == false"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,7 +34,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add 'services/*/package.json' 'libs/*/package.json'
-          git diff --staged --quiet || git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git diff --staged --quiet || git commit -m "release: ${{ steps.version.outputs.version }}"
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push and create release


### PR DESCRIPTION
Cleaner syntax. Deploy runs only on release commits, not on merge — one deploy per merge.