### PR TITLE
fix: deployment gate, Docker workspace + husky fix

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -51,8 +51,9 @@ flowchart LR
 1. Branch from `next`, make changes, commit, push.
 2. **Ask the user** if they want to create a PR. Only create when confirmed.
 3. `gh pr create` → open PR targeting `next`.
-4. **Ask the user** if they want to merge. Only merge when confirmed.
-5. `gh pr merge --rebase` → merge into `next`.
+4. CI runs (Lint & Format + Build). **Both must pass** before merge.
+5. **Ask the user** if they want to merge. Only merge when confirmed.
+6. `gh pr merge --rebase` → merge into `next`.
 
 **CI flow (after merge):**
 1. Push to `next` triggers `version-tag` and `deploy-next`.
@@ -123,11 +124,15 @@ gh pr merge <number> --rebase
 - **Runs only on:** `[release]` commits (version-tag push) or workflow_dispatch. Skips merge commits — deploy once per merge.
 - Deploys maia and moai to Fly.io (parallel).
 
-### Biome (`.github/workflows/biome.yml`)
+### CI (`.github/workflows/biome.yml`)
 
 - **Trigger:** Pull requests and pushes to `next`.
-- **Runs:** `bun run check:ci` (lint + format check).
-- **Branch protection:** Require the Biome status check before PRs can merge into `next`. Settings → Branches → Rules for `next` → Require status checks to pass → Add checks. If "No results" appears, **manually type** `Lint & Format` or `biome` (the check name only appears after the workflow has run at least once—push a PR, let it run, then it will be searchable).
+- **Jobs:**
+  1. **Lint & Format** – `bun run check:ci` (Biome + .maia format check).
+  2. **Build (maia + moai)** – Docker build for both services. Validates deployment will succeed before merge.
+- **Branch protection:** Require **both** jobs before PRs can merge into `next`. Settings → Branches → Rules for `next` → Require status checks → Add `Lint & Format` and `Build (maia + moai)`. If "No results" appears, push a PR, let the workflow run once, then the check names become searchable.
+- **Deployment gate:** PRs cannot merge until the Build job passes. This prevents merging code that would break the deploy pipeline.
+- **When changing:** Dockerfiles, `package.json` workspaces, or deploy scripts — ensure the Build job passes before merging.
 
 ---
 

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,4 +1,4 @@
-name: Biome
+name: CI
 
 on:
   pull_request:
@@ -22,3 +22,15 @@ jobs:
 
       - name: Run Biome
         run: bun run check:ci
+
+  build:
+    name: Build (maia + moai)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build maia image
+        run: docker build -f services/maia/Dockerfile -t maia:test .
+
+      - name: Build moai image
+        run: docker build -f services/moai/Dockerfile -t moai:test .

--- a/services/maia/Dockerfile
+++ b/services/maia/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY package.json bun.lock* ./
 COPY libs ./libs
 COPY services/maia ./services/maia
+COPY services/moai ./services/moai
 
 # VITE_PEER_MOAI must be set BEFORE bundles:build - kernel bundle contains sync logic and inlines this
 ARG VITE_PEER_MOAI=moai.next.maia.city
@@ -18,6 +19,8 @@ ARG VITE_PEER_MAIA=next.maia.city
 ENV VITE_PEER_MAIA=$VITE_PEER_MAIA
 
 # Build kernel + vibes bundles (kernel needs VITE_PEER_MOAI for sync domain)
+# HUSKY=0 skips prepare script (git hooks not needed in Docker)
+ENV HUSKY=0
 RUN bun install
 RUN bun run bundles:build
 

--- a/services/moai/Dockerfile
+++ b/services/moai/Dockerfile
@@ -5,12 +5,15 @@ FROM oven/bun:1-slim
 
 WORKDIR /app
 
-# Copy workspace files
-COPY package.json bun.lock ./
-COPY services/moai ./services/moai
+# Copy workspace files (all workspaces required by root package.json)
+COPY package.json bun.lock* ./
 COPY libs ./libs
+COPY services/maia ./services/maia
+COPY services/moai ./services/moai
 
 # Install dependencies (resolves workspace:* from root)
+# HUSKY=0 skips prepare script (git hooks not needed in Docker)
+ENV HUSKY=0
 RUN bun install
 
 # Moai runs on 4201


### PR DESCRIPTION
## Changes
- **CI:** Add Build job to validate Docker builds (maia + moai) on every PR
- **Docker:** Add missing workspace copies (maia ↔ moai) so bun install resolves all workspaces
- **Docker:** Set HUSKY=0 to skip prepare script (git hooks not needed in containers)
- **Rule:** Update continous-versioning.mdc – require both Lint & Format and Build before merge

Branch protection: Add `Build (maia + moai)` as required check for `next`.