### PR TITLE
[chore] Maia service compact and simplify

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -11,7 +11,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event.head_commit != null && startsWith(github.event.head_commit.message, '[release] '))
     name: Deploy moai
     runs-on: ubuntu-latest
-    environment: next
+    environment:
+      name: Next
+      url: https://moai.next.maia.city/health
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
@@ -30,7 +32,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event.head_commit != null && startsWith(github.event.head_commit.message, '[release] '))
     name: Deploy maia
     runs-on: ubuntu-latest
-    environment: next
+    environment:
+      name: Next
+      url: https://next.maia.city
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@MaiaOS/schemata": "workspace:*",
         "@MaiaOS/script": "workspace:*",
         "@MaiaOS/storage": "workspace:*",
+        "@MaiaOS/tools": "workspace:*",
         "cojson": "^0.20.7",
         "cojson-transport-ws": "0.20.7",
       },

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+# Root Bun config - applies to maia, moai, and libs
+# .maia files treated as JSON (required for @MaiaOS/vibes imports)
+[loader]
+".maia" = "json"

--- a/libs/maia-core/src/index.js
+++ b/libs/maia-core/src/index.js
@@ -8,6 +8,7 @@ export {
 	getSchemaIndexColistId,
 	resolveAccountCoIdsToProfileNames,
 	resolveGroupCoIdsToCapabilityNames,
+	schemaMigration,
 	setupSyncPeers,
 	subscribeSyncState,
 	waitForStoreReady,

--- a/libs/maia-db/README.md
+++ b/libs/maia-db/README.md
@@ -33,7 +33,7 @@ MaiaOS Operations (maia.db({ op: 'read', ... }))
 - `setupSyncPeers`, `subscribeSyncState` - Sync peer configuration
 - `createGroup`, `createProfile`, `createCoMap`, `createCoList`, `createCoStream`
 - `createAndPushMessage`, `processInbox` - Inbox handling
-- `seedAgentAccount`, `schemaMigration` - Bootstrap and migration
+- `simpleAccountSeed`, `schemaMigration` - Bootstrap and migration
 
 ## Project Structure
 

--- a/libs/maia-db/src/cojson/core/cojson-backend.js
+++ b/libs/maia-db/src/cojson/core/cojson-backend.js
@@ -257,12 +257,12 @@ export class CoJSONBackend extends DBAdapter {
 	/**
 	 * Add a member to a group
 	 * @param {RawGroup} group - Group CoValue
-	 * @param {string} memberId - Member ID (account or group Co-ID)
+	 * @param {string} accountCoId - Account co-id (co_z...) - agent ID resolved internally, never exposed
 	 * @param {string} role - Role name
 	 * @returns {Promise<void>}
 	 */
-	async addGroupMember(group, memberId, role) {
-		return await groups.addGroupMember(this.node, group, memberId, role, this)
+	async addGroupMember(group, accountCoId, role) {
+		return await groups.addGroupMember(this.node, group, accountCoId, role, this)
 	}
 
 	/**
@@ -622,15 +622,16 @@ export class CoJSONBackend extends DBAdapter {
 	 * @param {Object} configs - Config registry {vibe, styles, actors, views, contexts, states, interfaces}
 	 * @param {Object} schemas - Schema definitions
 	 * @param {Object} data - Initial application data {todos: [], ...}
+	 * @param {Object} [options] - Options (forceFreshSeed: bypass co-value checks, always bootstrap)
 	 * @returns {Promise<Object>} Summary of what was seeded
 	 */
-	async seed(configs, schemas, data) {
+	async seed(configs, schemas, data, options = {}) {
 		if (!this.account) {
 			throw new Error('[CoJSONBackend] Account required for seed')
 		}
 
 		// Pass backend instance so dbEngine is available for schema validation during seeding
-		return await seed(this.account, this.node, configs, schemas, data || {}, this)
+		return await seed(this.account, this.node, configs, schemas, data || {}, this, options)
 	}
 
 	/**

--- a/libs/maia-db/src/index.js
+++ b/libs/maia-db/src/index.js
@@ -61,7 +61,7 @@ export {
 	resolve,
 	resolveReactive,
 } from './cojson/schema/resolver.js'
-export { seedAgentAccount } from './cojson/schema/seed.js'
+export { simpleAccountSeed } from './cojson/schema/seed.js'
 export { schemaMigration } from './migrations/schema.migration.js'
 export {
 	createSchemaMeta,

--- a/libs/maia-docs/03_developers/05_maia-db/groups.md
+++ b/libs/maia-docs/03_developers/05_maia-db/groups.md
@@ -126,6 +126,21 @@ childGroup.extend(parentGroup, "reader"); // All parent members get reader acces
 - `"admin"` - All parent members get admin access
 - `"revoked"` - Delegation revoked
 
+## Group Member Contract
+
+MaiaOS standardizes on **account co-ids** (co_z...) for group member storage and display. Never use agent IDs (sealer_z.../signer_z...) at the API or display layers.
+
+**Storage:**
+- Groups store **account co-ids** as member keys when using `addGroupMember`.
+- CoJSON supports both account co-ids and agent IDs; we standardize on account co-id for consistency and profile resolution.
+
+**API and display:**
+- Accept and expose **account co-id only**. Agent ID is internal (used for crypto/key revelation) and never accepted, returned, or logged at the API boundary.
+- `resolveAccountCoIdsToProfileNames` expects account co-ids; agent IDs are never resolved (by design).
+- For legacy data that may contain agent IDs, the frontend displays "Agent X" as a fallback instead of raw sealer_z/signer_z strings.
+
+**Implementation:** `addGroupMember` passes an account-like object `{ id: accountCoId, currentAgentID: () => agentId }` to CoJSON, so the group stores `account.id` (co_z) as the member key while using agent ID only for cryptographic operations.
+
 ## Implementation Files
 
 - **Group Creation:** `libs/maia-db/src/cojson/groups/create.js`

--- a/libs/maia-docs/03_developers/state-and-persistence.md
+++ b/libs/maia-docs/03_developers/state-and-persistence.md
@@ -66,13 +66,16 @@ The sync service and agent use PGlite for CoValue storage. Two modes matter:
 
 ---
 
-## Vibe Seeding: Human vs Agent Mode
+## Seeding: Two Modes
 
-**`VITE_MAIA_CITY_SEED_VIBES`** controls which vibes (todos, chat, db, sparks, creator) are auto-seeded when a new account is created. It only applies in **human mode** (browser sign-up via passkey).
+**simpleAccountSeed** – Empty `account.sparks` only. Used for all signups (human + agent).
 
-| Mode | Where | `VITE_MAIA_CITY_SEED_VIBES` | Behavior |
-|------|-------|-----------------------------|----------|
-| **Human** | maia-city (browser) | `todos,chat,db,sparks,creator` or `all` | On sign-up, `createAccountWithSecret` reads this env (via `import.meta.env`). `filterVibesForSeeding` seeds the specified vibes into the new account. Default: `all` if unset. |
-| **Agent** | sync service | N/A | `loadOrCreateAgentAccount` uses `skipAutoSeeding: true`. No vibe seeding; sync server only needs bootstrap data. |
+**genesisAccountSeed** – Full scaffold + vibes. Only when **PEER_MODE=sync** (moai sync server).
 
-**Values**: `"none"` (no seeding), `"all"` (all vibes), or comma-separated: `"todos,chat,db,sparks,creator"`.
+| Trigger | Mode | Behavior |
+|---------|------|----------|
+| **createAccountWithSecret** (human or agent) | simpleAccountSeed | Empty account.sparks. Vibes come from sync when human connects. |
+| **Moai PEER_MODE=sync** | genesisAccountSeed | Full scaffold + vibes into sync server account. |
+| **handleSeed** (agent mode, manual) | genesisAccountSeed | Manual reseed for dev. |
+
+**SEED_VIBES** (moai env) controls which vibes moai seeds when PEER_MODE=sync: `"all"` or comma-separated `"todos,chat,db,sparks,creator"`.

--- a/libs/maia-operations/src/operations.js
+++ b/libs/maia-operations/src/operations.js
@@ -127,10 +127,11 @@ export async function deleteOperation(backend, dbEngine, params) {
 }
 
 export async function seedOperation(backend, params) {
-	const { configs, schemas, data } = params
+	const { configs, schemas, data, forceFreshSeed } = params
 	if (!configs) throw new Error('[SeedOperation] Configs required')
 	if (!schemas) throw new Error('[SeedOperation] Schemas required')
-	const result = await backend.seed(configs, schemas, data || {})
+	const options = forceFreshSeed ? { forceFreshSeed: true } : {}
+	const result = await backend.seed(configs, schemas, data || {}, options)
 	return createSuccessResult(result, { op: 'seed' })
 }
 

--- a/libs/maia-self/src/self.js
+++ b/libs/maia-self/src/self.js
@@ -77,7 +77,7 @@ export async function signUpWithPasskey({ name, salt = 'maia.city' } = {}) {
 	const syncSetup = setupSyncPeers()
 
 	// Use createAccountWithSecret() abstraction from @MaiaOS/db
-	// This ensures consistent account creation through the abstraction layer
+	// Human signup always minimal (no vibe seeding); server seeds vibes
 	const createResult = await createAccountWithSecret({
 		agentSecret,
 		name,
@@ -291,13 +291,12 @@ export async function createAgentAccount({
 	const syncSetup = setupSyncPeers(syncDomain)
 
 	// Use createAccountWithSecret() abstraction from @MaiaOS/db
-	// Skip auto-seeding for agent accounts (they don't need vibes/views - that's for human users)
+	// All signups get simpleAccountSeed; genesis (full scaffold) is PEER_MODE=sync only
 	const createResult = await createAccountWithSecret({
 		agentSecret,
 		name,
 		peers: syncSetup ? syncSetup.peers : [],
 		storage: storage,
-		skipAutoSeeding: true, // Agent accounts don't need vibes/views seeding
 	})
 
 	const { node, account, accountID: createdAccountID } = createResult

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -44,6 +44,17 @@ function shouldFilterLine(line) {
 		return true
 	}
 
+	// Filter verbose seed logs ([Seed], Bootstrap scaffold, Auto-seeding, etc.)
+	if (
+		trimmed.startsWith('[Seed]') ||
+		trimmed.includes('Bootstrap scaffold complete') ||
+		trimmed.includes('Auto-seeding') ||
+		trimmed.includes('Cleaning up existing seeded') ||
+		trimmed.includes('Cleanup complete: deleted')
+	) {
+		return true
+	}
+
 	// Filter verbose build/output
 	if (
 		trimmed.includes('modules transformed') ||

--- a/services/maia/Dockerfile
+++ b/services/maia/Dockerfile
@@ -27,9 +27,9 @@ RUN bun run distros:build
 RUN bun scripts/generate-favicons.js
 
 # Build maia frontend (runs sync-assets → dist/brand, then bundles)
+# serverOwnsVibes is standard default (not configurable): minimal human account + symlink via /syncRegistry
 RUN cd services/maia && \
   NODE_ENV=production \
-  VITE_SEED_VIBES=all \
   VITE_PEER_MOAI=${VITE_PEER_MOAI:-moai.next.maia.city} \
   VITE_PEER_MAIA=${VITE_PEER_MAIA:-next.maia.city} \
   bun build.js

--- a/services/maia/css/db.css
+++ b/services/maia/css/db.css
@@ -1886,6 +1886,56 @@ pre {
 	}
 }
 
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}
+
+.loading-connecting-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.85);
+	backdrop-filter: blur(10px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	gap: 2rem;
+	z-index: 1000;
+	text-align: center;
+	color: white;
+}
+
+.loading-connecting-overlay .loading-spinner {
+	width: 64px;
+	height: 64px;
+	border: 4px solid rgba(255, 255, 255, 0.2);
+	border-top-color: rgba(255, 255, 255, 0.8);
+	animation: spin 1s linear infinite;
+}
+
+.loading-connecting-sync {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 1rem;
+	background: rgba(255, 255, 255, 0.1);
+	border-radius: 8px;
+	font-size: 0.875rem;
+	margin-top: 1rem;
+}
+
+.loading-connecting-indicator {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+}
+
 .loading-hint {
 	font-size: 0.875rem;
 	color: var(--slate-500);

--- a/services/maia/css/landing.css
+++ b/services/maia/css/landing.css
@@ -1,0 +1,226 @@
+/* Landing Page – styles extracted from landing.js */
+
+.landing-main {
+	overflow-x: hidden;
+	box-sizing: border-box;
+}
+
+.landing-main .hero {
+	min-height: 92vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding-top: 0;
+	margin-top: 0;
+	position: relative;
+}
+
+.landing-banner {
+	margin-bottom: 2rem;
+	font-family: var(--font-body);
+	font-size: clamp(1.2rem, 3vw, 1.8rem);
+	line-height: 1.6;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	text-align: center;
+	color: var(--color-tinted-white);
+	text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.landing-headline {
+	font-size: clamp(2.5rem, 6vw, 4.5rem);
+	margin-bottom: 0;
+	text-align: center;
+	line-height: 1.2;
+}
+
+.landing-headline span {
+	display: inline-block;
+	padding: 0.2rem 1.2rem;
+	background: rgba(0, 189, 214, 0.25);
+	backdrop-filter: blur(8px);
+	border-radius: 8px;
+	margin-top: 0.5rem;
+	border: 1px solid rgba(0, 189, 214, 0.3);
+	box-shadow: 0 0 30px rgba(0, 189, 214, 0.2);
+}
+
+.landing-story-opener {
+	position: absolute;
+	bottom: 10%;
+	left: 50%;
+	transform: translateX(-50%);
+	font-family: var(--font-body);
+	font-size: clamp(0.75rem, 1.5vw, 0.85rem);
+	color: var(--color-marine-blue);
+	letter-spacing: 0.3em;
+	text-transform: uppercase;
+	font-weight: 800;
+	padding: 0.5rem 2rem;
+	background: var(--color-soft-clay);
+	border-radius: 50px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+	z-index: 10;
+}
+
+.landing-story {
+	margin-top: 0;
+	padding-top: 2rem;
+	display: grid;
+	grid-template-columns: repeat(12, 1fr);
+	gap: 1.5rem;
+	max-width: 1100px;
+	width: 100%;
+	box-sizing: border-box;
+	padding-left: 1rem;
+	padding-right: 1rem;
+	margin-left: auto;
+	margin-right: auto;
+	align-items: center;
+}
+
+.landing-chunk {
+	font-family: var(--font-heading);
+	font-style: italic;
+	line-height: 1.3;
+	background: rgba(255, 255, 255, 0.12);
+	backdrop-filter: blur(20px) saturate(160%);
+	border-radius: 24px;
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	color: var(--color-tinted-white);
+	text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.landing-chunk-1 {
+	grid-column: 2 / span 7;
+	justify-self: start;
+	max-width: 100%;
+	font-size: clamp(1.6rem, 4vw, 2.8rem);
+	padding: 2rem;
+	transform: rotate(-1deg);
+	margin-left: 1rem;
+}
+
+.landing-chunk-2 {
+	grid-column: 4 / -1;
+	justify-self: end;
+	max-width: 100%;
+	font-size: clamp(1.6rem, 4vw, 2.8rem);
+	padding: 2rem;
+	background: rgba(255, 255, 255, 0.18);
+	backdrop-filter: blur(25px) saturate(180%);
+	border-color: rgba(255, 255, 255, 0.35);
+	margin-top: -1rem;
+	z-index: 2;
+	transform: rotate(1deg);
+	margin-right: 1rem;
+}
+
+.landing-chunk-3 {
+	grid-column: 1 / -1;
+	justify-self: center;
+	font-size: clamp(1.4rem, 3.2vw, 2.2rem);
+	padding: 1.5rem 3rem;
+	background: rgba(255, 255, 255, 0.15);
+	margin-top: -0.5rem;
+	z-index: 1;
+}
+
+.landing-chunk-4 {
+	grid-column: 2 / 12;
+	font-size: clamp(1.2rem, 3vw, 2rem);
+	line-height: 1.5;
+	text-align: center;
+	padding: 3rem 2.5rem;
+	background: rgba(0, 31, 51, 0.4);
+	backdrop-filter: blur(15px);
+	border-radius: 30px;
+	border: 1px solid rgba(0, 189, 214, 0.3);
+	margin-top: 0;
+	position: relative;
+}
+
+.landing-chunk .terracotta {
+	color: var(--color-terracotta);
+	text-shadow: 0 0 20px rgba(194, 123, 102, 0.4);
+}
+.landing-chunk .sun-yellow {
+	color: var(--color-sun-yellow);
+	font-weight: 700;
+	text-shadow: 0 0 30px rgba(230, 185, 77, 0.5);
+}
+.landing-chunk .paradise-water {
+	color: var(--color-paradise-water);
+	text-shadow: 0 0 20px rgba(0, 189, 214, 0.5);
+}
+.landing-chunk .lush-green {
+	color: var(--color-lush-green);
+	font-weight: 700;
+	text-shadow: 0 0 20px rgba(78, 154, 88, 0.6);
+}
+.landing-chunk .paradise-water-bright {
+	color: var(--color-paradise-water);
+	font-weight: 700;
+	text-shadow: 0 0 20px rgba(0, 189, 214, 0.6);
+}
+
+.landing-logo {
+	grid-column: 1 / -1;
+	justify-self: center;
+	margin: 3rem 0;
+}
+
+.landing-logo img {
+	height: clamp(8rem, 18vw, 14rem);
+	filter: drop-shadow(0 0 50px rgba(0, 189, 214, 0.7));
+}
+
+.landing-cta {
+	grid-column: 1 / -1;
+	justify-self: center;
+	margin-top: 4rem;
+	margin-bottom: 8rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1.2rem;
+}
+
+.landing-cta-text {
+	font-family: var(--font-body);
+	color: var(--color-tinted-white);
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+	font-weight: 800;
+	text-shadow: 0 0 30px rgba(232, 225, 217, 0.4);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
+.landing-cta-text .lead {
+	font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+}
+.landing-cta-text .amp {
+	color: var(--color-tinted-white);
+	font-size: 1.2em;
+	font-family: var(--font-heading);
+	font-style: italic;
+	opacity: 0.9;
+}
+.landing-cta-text .sub {
+	font-size: clamp(0.9rem, 1.8vw, 1.3rem);
+	opacity: 0.9;
+}
+
+.landing-cta .btn {
+	background: rgba(78, 154, 88, 0.8);
+	color: #f0ede6;
+	font-size: 1.2rem;
+	padding: 1.2rem 5rem;
+	letter-spacing: 0.15em;
+	box-shadow: 0 0 40px rgba(78, 154, 88, 0.4);
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	backdrop-filter: blur(8px);
+}

--- a/services/maia/dashboard.js
+++ b/services/maia/dashboard.js
@@ -254,6 +254,16 @@ export async function renderDashboard(
 	_loadSpark,
 	_loadVibe,
 ) {
+	// Require signed-in account (maia.id = { maiaId, node })
+	if (!maia?.id?.maiaId || !maia.id.node) {
+		document.getElementById('app').innerHTML = `
+			<div class="flex flex-col justify-center items-center min-h-[60vh] text-slate-500">
+				<p class="font-medium">${authState?.signedIn ? 'Loading account…' : 'Please sign in.'}</p>
+			</div>
+		`
+		return
+	}
+
 	const accountId = maia?.id?.maiaId?.id || ''
 	let accountDisplayName = truncate(accountId, 12)
 	if (accountId?.startsWith('co_z') && maia?.db) {

--- a/services/maia/db-view.js
+++ b/services/maia/db-view.js
@@ -11,17 +11,7 @@ import {
 	resolveGroupCoIdsToCapabilityNames,
 } from '@MaiaOS/core'
 import { renderDashboard, renderVibeViewer } from './dashboard.js'
-import { getSyncStatusMessage, truncate } from './utils.js'
-
-// Helper function to escape HTML
-function escapeHtml(text) {
-	if (text === null || text === undefined) {
-		return ''
-	}
-	const div = document.createElement('div')
-	div.textContent = String(text)
-	return div.innerHTML
-}
+import { escapeHtml, getSyncStatusMessage, truncate } from './utils.js'
 
 export async function renderApp(
 	maia,

--- a/services/maia/landing.js
+++ b/services/maia/landing.js
@@ -1,207 +1,41 @@
 /**
- * Landing Page Rendering
- * Displays the MaiaCity landing page with hero section and story
+ * Landing Page – hero section and story
  */
 
 export function renderLandingPage() {
 	document.getElementById('app').innerHTML = `
-		<main class="container landing-main" style="overflow-x: hidden; box-sizing: border-box;">
-			<!-- THE MASTER HOOK -->
-			<section class="hero" style="
-				min-height: 92vh;
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
-				padding-top: 0;
-				margin-top: 0;
-				position: relative;
-			">
-				<!-- Banner Text -->
-				<div style="
-					margin-bottom: 2rem;
-					font-family: var(--font-body);
-					font-size: clamp(1.2rem, 3vw, 1.8rem);
-					line-height: 1.6;
-					font-weight: 500;
-					letter-spacing: 0.02em;
-					text-align: center;
-					color: var(--color-tinted-white);
-					text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-				">
-					We were never meant to live small.
-				</div>
-
-				<!-- Main Headline -->
-				<h1 style="font-size: clamp(2.5rem, 6vw, 4.5rem); margin-bottom: 0; text-align: center; line-height: 1.2;">
+		<main class="container landing-main">
+			<section class="hero">
+				<div class="landing-banner">We were never meant to live small.</div>
+				<h1 class="landing-headline">
 					MaiaCity is the place where<br>
-					<span style="
-						display: inline-block;
-						padding: 0.2rem 1.2rem;
-						background: rgba(0, 189, 214, 0.25);
-						backdrop-filter: blur(8px);
-						border-radius: 8px;
-						margin-top: 0.5rem;
-						border: 1px solid rgba(0, 189, 214, 0.3);
-						box-shadow: 0 0 30px rgba(0, 189, 214, 0.2);
-					"><em>humans true potential</em></span> comes to life.
+					<span><em>humans true potential</em></span> comes to life.
 				</h1>
-
-				<!-- Story Opener - Positioned at bottom of hero -->
-				<div class="landing-story-opener" style="
-					position: absolute;
-					bottom: 10%;
-					left: 50%;
-					transform: translateX(-50%);
-					font-family: var(--font-body);
-					font-size: clamp(0.75rem, 1.5vw, 0.85rem);
-					color: var(--color-marine-blue);
-					letter-spacing: 0.3em;
-					text-transform: uppercase;
-					font-weight: 800;
-					padding: 0.5rem 2rem;
-					background: var(--color-soft-clay);
-					border-radius: 50px;
-					box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-					z-index: 10;
-				">This is the story of</div>
+				<div class="landing-story-opener">This is the story of</div>
 			</section>
-
-			<!-- THE STORY SECTION -->
-			<section class="landing-story" style="
-				margin-top: 0;
-				padding-top: 2rem;
-				display: grid;
-				grid-template-columns: repeat(12, 1fr);
-				gap: 1.5rem;
-				max-width: 1100px;
-				width: 100%;
-				box-sizing: border-box;
-				padding-left: 1rem;
-				padding-right: 1rem;
-				margin-left: auto;
-				margin-right: auto;
-				align-items: center;
-			">
-				<!-- Chunk 1: Who -->
-				<div class="landing-chunk landing-chunk-1" style="
-					grid-column: 2 / span 7;
-					justify-self: start;
-					max-width: 100%;
-					font-family: var(--font-heading);
-					font-style: italic;
-					font-size: clamp(1.6rem, 4vw, 2.8rem);
-					line-height: 1.3;
-					padding: 2rem;
-					background: rgba(255, 255, 255, 0.12);
-					backdrop-filter: blur(20px) saturate(160%);
-					border-radius: 24px;
-					border: 1px solid rgba(255, 255, 255, 0.25);
-					color: var(--color-tinted-white);
-					text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-					transform: rotate(-1deg);
-					margin-left: 1rem;
-				">
-					how <strong style="color: var(--color-terracotta); text-shadow: 0 0 20px rgba(194, 123, 102, 0.4);">1.3 million</strong> maia citizens
+			<section class="landing-story">
+				<div class="landing-chunk landing-chunk-1">
+					how <strong class="terracotta">1.3 million</strong> maia citizens
 				</div>
-
-				<!-- Chunk 2: What -->
-				<div class="landing-chunk landing-chunk-2" style="
-					grid-column: 4 / -1;
-					justify-self: end;
-					max-width: 100%;
-					font-family: var(--font-heading);
-					font-style: italic;
-					font-size: clamp(1.6rem, 4vw, 2.8rem);
-					line-height: 1.3;
-					padding: 2rem;
-					background: rgba(255, 255, 255, 0.18);
-					backdrop-filter: blur(25px) saturate(180%);
-					border-radius: 24px;
-					border: 1px solid rgba(255, 255, 255, 0.35);
-					color: var(--color-tinted-white);
-					text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-					margin-top: -1rem;
-					z-index: 2;
-					transform: rotate(1deg);
-					margin-right: 1rem;
-				">
-					<strong style="color: var(--color-sun-yellow); font-weight: 700; text-shadow: 0 0 30px rgba(230, 185, 77, 0.5);">craft</strong> from the ground up
+				<div class="landing-chunk landing-chunk-2">
+					<strong class="sun-yellow">craft</strong> from the ground up
 				</div>
-
-				<!-- Chunk 3: Timeline -->
-				<div class="landing-chunk landing-chunk-3" style="
-					grid-column: 1 / -1;
-					justify-self: center;
-					font-family: var(--font-heading);
-					font-style: italic;
-					font-size: clamp(1.4rem, 3.2vw, 2.2rem);
-					line-height: 1.3;
-					padding: 1.5rem 3rem;
-					background: rgba(255, 255, 255, 0.15);
-					backdrop-filter: blur(20px) saturate(160%);
-					border-radius: 24px;
-					border: 1px solid rgba(255, 255, 255, 0.25);
-					color: var(--color-tinted-white);
-					text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-					z-index: 1;
-					margin-top: -0.5rem;
-				">
-					in less than <strong style="color: var(--color-paradise-water); text-shadow: 0 0 20px rgba(0, 189, 214, 0.5);">16 years</strong>
+				<div class="landing-chunk landing-chunk-3">
+					in less than <strong class="paradise-water">16 years</strong>
 				</div>
-
-				<!-- LOGO STANDALONE -->
-				<div class="landing-logo" style="grid-column: 1 / -1; justify-self: center; margin: 3rem 0;">
-					<img src="/brand/logo.svg" alt="MaiaCity Logo" style="height: clamp(8rem, 18vw, 14rem); filter: drop-shadow(0 0 50px rgba(0, 189, 214, 0.7));" />
+				<div class="landing-logo">
+					<img src="/brand/logo.svg" alt="MaiaCity Logo" />
 				</div>
-
-				<!-- Chunk 4: Why -->
-				<div class="landing-chunk landing-chunk-4" style="
-					grid-column: 2 / 12;
-					font-family: var(--font-heading);
-					font-style: italic;
-					font-size: clamp(1.2rem, 3vw, 2rem);
-					line-height: 1.5;
-					text-align: center;
-					padding: 3rem 2.5rem;
-					background: rgba(0, 31, 51, 0.4);
-					backdrop-filter: blur(15px);
-					border-radius: 30px;
-					border: 1px solid rgba(0, 189, 214, 0.3);
-					color: var(--color-tinted-white);
-					margin-top: 0;
-					position: relative;
-				">
-					<span>Earth's new capital, where <strong style="color: var(--color-paradise-water); font-weight: 700; text-shadow: 0 0 20px rgba(0, 189, 214, 0.6);">civilization-shaping</strong> visions become reality at <strong style="color: var(--color-lush-green); font-weight: 700; text-shadow: 0 0 20px rgba(78, 154, 88, 0.6);">100x growth</strong></span>
+				<div class="landing-chunk landing-chunk-4">
+					<span>Earth's new capital, where <strong class="paradise-water-bright">civilization-shaping</strong> visions become reality at <strong class="lush-green">100x growth</strong></span>
 				</div>
-
-				<!-- CTA Button Area -->
-				<div style="grid-column: 1 / -1; justify-self: center; margin-top: 4rem; margin-bottom: 8rem; display: flex; flex-direction: column; align-items: center; gap: 1.2rem;">
-					<div style="
-						font-family: var(--font-body);
-						color: var(--color-tinted-white);
-						letter-spacing: 0.15em;
-						text-transform: uppercase;
-						font-weight: 800;
-						text-shadow: 0 0 30px rgba(232, 225, 217, 0.4);
-						text-align: center;
-						display: flex;
-						flex-direction: column;
-						gap: 0.4rem;
-					">
-						<span style="font-size: clamp(1.2rem, 2.5vw, 1.8rem);">Reclaim your sovereignty</span>
-						<span style="color: var(--color-tinted-white); font-size: 1.2em; font-family: var(--font-heading); font-style: italic; opacity: 0.9;">&</span>
-						<span style="font-size: clamp(0.9rem, 1.8vw, 1.3rem); opacity: 0.9;">become a maia citizen</span>
+				<div class="landing-cta">
+					<div class="landing-cta-text">
+						<span class="lead">Reclaim your sovereignty</span>
+						<span class="amp">&</span>
+						<span class="sub">become a maia citizen</span>
 					</div>
-					<button class="btn" style="
-						background: rgba(78, 154, 88, 0.8);
-						color: #F0EDE6;
-						font-size: 1.2rem; 
-						padding: 1.2rem 5rem; 
-						letter-spacing: 0.15em; 
-						box-shadow: 0 0 40px rgba(78, 154, 88, 0.4);
-						border: 1px solid rgba(255, 255, 255, 0.2);
-						backdrop-filter: blur(8px);
-					" onclick="event.preventDefault(); window.navigateTo('/signin'); return false;">JOIN NOW</button>
+					<button class="btn" onclick="event.preventDefault(); window.navigateTo('/signin'); return false;">JOIN NOW</button>
 				</div>
 			</section>
 		</main>

--- a/services/maia/style.css
+++ b/services/maia/style.css
@@ -4,5 +4,6 @@
 @import "./css/glass.css";
 @import "./css/components.css";
 @import "./css/hero.css";
+@import "./css/landing.css";
 @import "./css/auth.css";
 @import "./css/db.css";

--- a/services/maia/utils.js
+++ b/services/maia/utils.js
@@ -8,27 +8,33 @@ export function truncate(str, maxLen = 40) {
 	return `${str.substring(0, maxLen)}...`
 }
 
+export function truncateWords(text, maxWords = 10) {
+	if (!text) return ''
+	const words = String(text).trim().split(/\s+/)
+	if (words.length <= maxWords) return text
+	return `${words.slice(0, maxWords).join(' ')}...`
+}
+
+export function escapeHtml(text) {
+	if (text === null || text === undefined) return ''
+	const div = document.createElement('div')
+	div.textContent = String(text)
+	return div.innerHTML
+}
+
 /**
  * Get sync status message based on status field
  * @param {Object} syncState - Sync state object with status field
+ * @param {string} [defaultMsg='Offline'] - Message when status is unknown (e.g. 'Connecting to sync...')
  * @returns {string} Status message
  */
-export function getSyncStatusMessage(syncState) {
-	if (syncState.status === 'authenticating') {
-		return 'Authenticating...'
-	} else if (syncState.status === 'loading-account') {
-		return 'Loading account...'
-	} else if (syncState.status === 'syncing') {
-		return 'Syncing'
-	} else if (syncState.status === 'connected') {
-		return 'Connected'
-	} else if (syncState.status === 'error') {
-		return syncState.error || 'Error'
-	} else if (syncState.connected) {
-		return syncState.syncing ? 'Syncing' : 'Connected'
-	} else if (syncState.error) {
-		return syncState.error
-	} else {
-		return 'Offline'
-	}
+export function getSyncStatusMessage(syncState, defaultMsg = 'Offline') {
+	if (syncState.status === 'authenticating') return 'Authenticating...'
+	if (syncState.status === 'loading-account') return 'Loading your account...'
+	if (syncState.status === 'syncing') return 'Syncing data...'
+	if (syncState.status === 'connected') return 'Connected'
+	if (syncState.status === 'error') return syncState.error || 'Error'
+	if (syncState.connected) return syncState.syncing ? 'Syncing' : 'Connected'
+	if (syncState.error) return syncState.error
+	return defaultMsg
 }

--- a/services/moai/README.md
+++ b/services/moai/README.md
@@ -21,7 +21,7 @@ This architecture ensures:
 
 The sync service consolidates WebSocket sync, agent API, and LLM proxy in one process. Endpoints:
 - `WS /sync` - CoJSON sync
-- `POST /on-added`, `/register-human`, `/trigger`, `/profile` - Agent API
+- `POST /register-human`, `GET /profile` - Agent API
 - `POST /api/v0/llm/chat` - LLM proxy (RedPill)
 
 ## Environment Variables
@@ -42,8 +42,9 @@ bun run dev:moai
 ## Endpoints
 
 - `GET /health` - Health check
+- `GET /syncRegistry` - Sync registry (@maia spark co-id)
 - `WS /sync` - WebSocket sync
-- `POST /on-added`, `/register-human`, `/trigger`, `/profile` - Agent API
+- `POST /register-human`, `GET /profile` - Agent API
 - `POST /api/v0/llm/chat` - LLM proxy
 
 ## Client Usage

--- a/services/moai/bunfig.toml
+++ b/services/moai/bunfig.toml
@@ -1,0 +1,3 @@
+# Moai service - .maia files must load as JSON for @MaiaOS/vibes imports
+[loader]
+".maia" = "json"

--- a/services/moai/package.json
+++ b/services/moai/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@MaiaOS/core": "workspace:*",
+		"@MaiaOS/vibes": "workspace:*",
 		"cojson-transport-ws": "0.20.7"
 	}
 }


### PR DESCRIPTION
Implements the compact/simplify plan for services/maia:

**Milestone 1 - Quick wins**
- Remove debugTodos (~95 lines)
- Deduplicate getSyncStatusMessage, escapeHtml
- Unify sync subscription setup
- Consolidate sidebar toggles

**Milestone 2 - main.js simplification**
- Simplify renderLoadingConnectingScreen (extract to CSS)
- Simplify showToast (Unicode icons)
- Trim handleRoute, loadLinkedCoValues, linkAccountToSyncRegistry

**Milestone 3 - Landing and dashboard**
- Move landing styles to css/landing.css (~165 lines saved)
- Add truncateWords to utils
- Tighten vibeHasBrowserRuntime / loadVibesFromSpark