### PR TITLE
[fix] Seed bootstrap cleanup, dev-server CSS, agent credential output

### DIFF
--- a/libs/maia-db/src/cojson/schema/seed.js
+++ b/libs/maia-db/src/cojson/schema/seed.js
@@ -1060,13 +1060,13 @@ export async function seed(
 	const coIdRegistry = new CoIdRegistry()
 
 	// Phase -1: Cleanup existing seeded co-values (but preserve schemata)
-	// This makes seeding idempotent - can be called multiple times safely
-	// Run cleanup if account was previously seeded (has schematas registry)
+	// Skip cleanup when we just bootstrapped - scaffold is fresh, nothing to clean.
+	// Cleanup only for reseeding an existing scaffold (would corrupt fresh bootstrap).
 	// NOTE: Schema index colists are automatically managed:
 	// - deleteRecord() automatically removes co-values from schema indexes via removeFromIndex()
 	// - create() operations automatically add co-values to schema indexes via storage hooks
 	// No manual index management needed during reseeding
-	const osIdForCleanup = await groups.getSparkOsId(backend, MAIA_SPARK)
+	const osIdForCleanup = needsBootstrap ? null : await groups.getSparkOsId(backend, MAIA_SPARK)
 	if (osIdForCleanup) {
 		try {
 			const osCoreForCleanup = await ensureCoValueLoaded(backend, osIdForCleanup, {

--- a/libs/maia-self/scripts/generate-credentials.js
+++ b/libs/maia-self/scripts/generate-credentials.js
@@ -60,7 +60,9 @@ ${accountMode === 'agent' ? '# PEER_MOAI=localhost:4201  # Set to sync server UR
 
 		log('✅ Credentials generated successfully!\n')
 
-		if (shouldWrite) {
+		if (!shouldWrite) {
+			console.log(envContent.trim())
+		} else if (shouldWrite) {
 			log('📋 Writing credentials to .env file...\n')
 			const envPath = join(rootDir, '.env')
 			let existingContent = existsSync(envPath) ? readFileSync(envPath, 'utf-8') : ''


### PR DESCRIPTION
- **Seed**: Skip Phase -1 cleanup when needsBootstrap (fixes fresh deploy corruption)
- **Dev server**: Serve /style.css and /css/* like /brand/* (fixes landing page styles in dev)
- **Agent credentials**: bun agent:generate --no-write now prints credentials