### PR TITLE
[fix] Add @MaiaOS/maia-ai as explicit app dependency for CI deploy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,6 @@ All commands are documented in root `package.json`. Key commands:
 
 1. **Generate credentials before first run**: `bun agent:generate` creates `/workspace/.env` with agent + test account credentials.
 2. **First run requires seeding**: Add `PEER_SYNC_SEED=true` and `PEER_SYNC_STORAGE=pglite` to `.env` for the first run. After successful seed, set `PEER_SYNC_SEED=false` so subsequent restarts use persisted data.
-3. **`@MaiaOS/maia-ai` resolution**: The `maia-ai-view.js` in `services/app` imports directly from `@MaiaOS/maia-ai`, but this package is not declared as a dependency in `services/app/package.json`. After `bun install`, manually symlink it: `cd services/app/node_modules/@MaiaOS && ln -s ../../../../libs/maia-ai maia-ai`. Without this, the app returns a 500 build error.
-4. **Test mode sign-in**: With `VITE_AVEN_TEST_MODE=true` in `.env`, the sign-in page shows a "SIGN IN / REGISTER WITH TEST AVEN" button that bypasses WebAuthn passkeys.
-5. **Guardian timeout on first run**: The sync server logs `Failed to add guardian: Timeout waiting for CoValue...` on first seed. This is expected — the test account isn't an existing peer yet. It does not block functionality.
-6. **RED_PILL_API_KEY**: Without this key, the LLM chat proxy (`/api/v0/llm/chat`) returns 500. The rest of the app works fine without it.
+3. **Test mode sign-in**: With `VITE_AVEN_TEST_MODE=true` in `.env`, the sign-in page shows a "SIGN IN / REGISTER WITH TEST AVEN" button that bypasses WebAuthn passkeys.
+4. **Guardian timeout on first run**: The sync server logs `Failed to add guardian: Timeout waiting for CoValue...` on first seed. This is expected — the test account isn't an existing peer yet. It does not block functionality.
+5. **RED_PILL_API_KEY**: Without this key, the LLM chat proxy (`/api/v0/llm/chat`) returns 500. The rest of the app works fine without it.

--- a/bun.lock
+++ b/bun.lock
@@ -161,6 +161,7 @@
       "version": "26.217.1438",
       "dependencies": {
         "@MaiaOS/loader": "workspace:*",
+        "@MaiaOS/maia-ai": "workspace:*",
         "@MaiaOS/maia-distros": "workspace:*",
       },
     },

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"@MaiaOS/loader": "workspace:*",
+		"@MaiaOS/maia-ai": "workspace:*",
 		"@MaiaOS/maia-distros": "workspace:*"
 	},
 	"devDependencies": {}


### PR DESCRIPTION
Fixes deploy:app failing in GitHub Actions with `Could not resolve: @MaiaOS/maia-ai`.

**Root cause:** `services/app` imports `@MaiaOS/maia-ai` in `maia-ai-view.js` but did not declare it in `package.json`. Local deploy could succeed (Depot cache, workspace hoisting) while CI failed on fresh builds.

**Changes:**
- Add `@MaiaOS/maia-ai` as explicit `workspace:*` dependency in `services/app/package.json`
- Remove manual symlink caveat from AGENTS.md