### PR TITLE
refactor(engines): remove runtime namekey fallbacks, 100% co-id refs

### DIFF
--- a/libs/maia-docs/03_developers/04_maia-engines/actor-communication/01-reference.md
+++ b/libs/maia-docs/03_developers/04_maia-engines/actor-communication/01-reference.md
@@ -66,8 +66,8 @@ The view subscribes to context changes:
 - Enables lazy loading and reuse
 
 **How**:
-- Child actors created lazily via `_createChildActorIfNeeded()`
-- Parent references child via `actor.children[namekey]`
+- Child actors created lazily via `_createChildActorByCoId()` (co-id only)
+- Parent references child via `actor.children[coId]`
 - Communication via inboxes, not direct state access
 
 ### 3. Reactive Queries
@@ -171,11 +171,11 @@ The view subscribes to context changes:
 **Use Case**: Render child actor in parent view
 
 **Steps**:
-1. Define child in parent context: `@actors: {detail: "@sparks/actor/detail"}`
-2. Reference child in view: `currentDetail: "@detail"`
+1. Define child in parent context: `@actors: {detail: "°Maia/actor/..."}` (transformed to co-ids during seeding)
+2. Reference child in view: `currentDetail: "co_z..."` (co-id, set by process/context)
 3. Use slot in view: `$slot: "$currentDetail"`
-4. View engine extracts namekey from `currentDetail`
-5. View engine calls `_createChildActorIfNeeded()`
+4. View engine reads co-id from `currentDetail`
+5. View engine calls `_createChildActorByCoId()`
 6. Child actor created lazily, attached to slot element
 
 **Example**: Agent view renders detail actor in slot

--- a/libs/maia-docs/03_developers/04_maia-engines/engines/00-overview.md
+++ b/libs/maia-docs/03_developers/04_maia-engines/engines/00-overview.md
@@ -33,10 +33,10 @@ The `@MaiaOS/engines` package provides the core engines that execute MaiaScript 
 - Processes inbox messages sequentially (`processEvents`)
 - Coordinates ViewEngine, StyleEngine, ProcessEngine
 - Batches rerenders (Svelte-style microtask queue)
-- Manages child actors (`_createChildActorIfNeeded`)
+- Manages child actors (`_createChildActorByCoId`)
 
 **Key Methods:**
-- `createActor(actorConfig, containerElement, agentKey)` - Create view-attached actor
+- `createActor(actorConfig, containerElement, vibeKey)` - Create view-attached actor
 - `spawnActor(actorConfig, options)` - Spawn headless actor
 - `destroyActor(actorId)` - Destroy single actor
 - `deliverEvent(senderId, targetId, type, payload)` - Deliver event to actor inbox

--- a/libs/maia-engines/src/engines/actor.engine.js
+++ b/libs/maia-engines/src/engines/actor.engine.js
@@ -187,26 +187,18 @@ export class ActorEngine {
 	}
 
 	/**
-	 * Create a child actor lazily if it doesn't exist yet
-	 * Only creates the child actor when it's actually needed (referenced by context.currentView)
+	 * Create a child actor by co-id. Runtime uses co-ids exclusively.
 	 * @param {Object} actor - Parent actor instance
-	 * @param {string} namekey - Child actor namekey (e.g., "list", "kanban")
+	 * @param {string} childActorCoId - Child actor co-id
 	 * @param {string} [vibeKey] - Optional vibe key for tracking child actors
 	 * @returns {Promise<Object|null>} The child actor instance, or null if not found/created
 	 * @private
 	 */
-	async _createChildActorIfNeeded(actor, namekey, _vibeKey = null) {
-		if (actor.children?.[namekey]) return actor.children[namekey]
+	async _createChildActorByCoId(actor, childActorCoId, _vibeKey = null) {
+		if (!childActorCoId?.startsWith('co_z')) return null
+		if (actor.children?.[childActorCoId]) return actor.children[childActorCoId]
 		if (!actor.children) actor.children = {}
 
-		// $stores Architecture: actor.context IS ReactiveStore with merged query results from backend
-		const contextValue = actor.context.value
-
-		if (!contextValue['@actors']?.[namekey]) return null
-		const childActorCoId = contextValue['@actors'][namekey]
-		if (!childActorCoId.startsWith('co_z')) {
-			throw new Error(`[ActorEngine] Child actor ID must be co-id: ${childActorCoId}`)
-		}
 		try {
 			const store = await readStore(this.dataEngine, childActorCoId)
 			if (!store) {
@@ -216,21 +208,12 @@ export class ActorEngine {
 			if (childActorConfig.$id !== childActorCoId) childActorConfig.$id = childActorCoId
 			const childContainer = document.createElement('div')
 			childContainer.style.display = 'contents'
-			childContainer.dataset.namekey = namekey
 			childContainer.dataset.childActorId = childActorCoId
-			const childActor = await this.createActor(
-				childActorConfig,
-				childContainer,
-				_vibeKey,
-				actor,
-				namekey,
-			)
-			childActor.namekey = namekey
-			actor.children[namekey] = childActor
+			const childActor = await this.createActor(childActorConfig, childContainer, _vibeKey)
+			actor.children[childActorCoId] = childActor
 			return childActor
 		} catch (error) {
-			console.error('[ActorEngine] _createChildActorIfNeeded FAILED:', {
-				namekey,
+			console.error('[ActorEngine] _createChildActorByCoId FAILED:', {
 				childActorCoId,
 				error: error.message,
 			})
@@ -238,13 +221,7 @@ export class ActorEngine {
 		}
 	}
 
-	async createActor(
-		actorConfig,
-		containerElement,
-		vibeKey = null,
-		parentActor = null,
-		namekey = null,
-	) {
+	async createActor(actorConfig, containerElement, vibeKey = null) {
 		const actorId = actorConfig.$id || actorConfig.id
 		if (this.actors.has(actorId)) {
 			return vibeKey
@@ -280,8 +257,6 @@ export class ActorEngine {
 			actorConfig,
 			vibeKey,
 			onBeforeRender,
-			parentActor,
-			namekey,
 		)
 		return actor
 	}

--- a/libs/maia-engines/src/engines/data.engine.js
+++ b/libs/maia-engines/src/engines/data.engine.js
@@ -346,14 +346,12 @@ function extractSchemaDefinition(coValueData, factoryCoId) {
 
 async function readFactoryOp(peer, params) {
 	const { factoryRef } = params
-	if (!factoryRef || typeof factoryRef !== 'string') {
-		throw new Error('[ReadSchemaOperation] factoryRef (schema namekey) is required')
+	if (!factoryRef || typeof factoryRef !== 'string' || !factoryRef.startsWith('co_z')) {
+		throw new Error(
+			'[ReadSchemaOperation] factoryRef must be a co-id (co_z...). Runtime uses co-ids only.',
+		)
 	}
-	const normalizedRef =
-		factoryRef.startsWith('°') || factoryRef.startsWith('@')
-			? factoryRef
-			: `°Maia/factory/${factoryRef}`
-	const factoryDef = await peer.resolve(normalizedRef, { returnType: 'factory' })
+	const factoryDef = await peer.resolve(factoryRef, { returnType: 'factory' })
 	if (!factoryDef) return null
 	const definition =
 		typeof factoryDef === 'object' && factoryDef !== null
@@ -384,17 +382,12 @@ async function createOp(peer, dataEngine, params) {
 	requireParam(factoryParam, 'factory', 'CreateOperation')
 	requireParam(data, 'data', 'CreateOperation')
 	requireDataEngine(dataEngine, 'CreateOperation', 'runtime schema validation')
-	const factoryCoId =
-		typeof factoryParam === 'string' && factoryParam.startsWith('co_z')
-			? factoryParam
-			: await peer.resolve(factoryParam, { returnType: 'coId' })
-	if (!factoryCoId) {
-		const registriesHint = peer.account?.get?.('registries')
-			? 'has registries'
-			: 'account.registries not set (link via sync?)'
-		console.error('[CreateOperation] Factory resolve failed:', factoryParam, registriesHint)
-		throw new Error(`[CreateOperation] Could not resolve factory: ${factoryParam}. ${registriesHint}`)
+	if (typeof factoryParam !== 'string' || !factoryParam.startsWith('co_z')) {
+		throw new Error(
+			`[CreateOperation] factory must be a co-id (co_z...). Runtime uses co-ids only. Got: ${factoryParam}`,
+		)
 	}
+	const factoryCoId = factoryParam
 	if (idempotencyKey && typeof idempotencyKey === 'string') {
 		const existing = await peer.findFirst(
 			factoryCoId,

--- a/libs/maia-engines/src/engines/view.engine.js
+++ b/libs/maia-engines/src/engines/view.engine.js
@@ -238,28 +238,11 @@ export class ViewEngine {
 	}
 
 	/**
-	 * Create fallback context when CoValue load fails. Universal: no hardcoded actor types.
-	 * Merges parent's @actors so child refs (e.g. $targetActor) resolve. Derives targetActor from
-	 * sibling slot when namekey indicates input-like child (tell target needs resolution).
-	 * @param {Object|null} parentActor - Parent actor (when child), for @actors propagation
-	 * @param {string|null} namekey - Child slot name when spawned from parent (e.g. 'input' => targetActor from @actors.messages)
+	 * Create fallback context when CoValue load fails. Empty store so actor spawns (no hard failure).
 	 * @returns {ReactiveStore} Store with minimal structure
 	 */
-	_createFallbackContext(parentActor = null, namekey = null) {
-		const base = {}
-		const parentValue = parentActor?.context?.value
-		if (parentValue?.['@actors'] && typeof parentValue?.['@actors'] === 'object') {
-			base['@actors'] = { ...parentValue['@actors'] }
-			// When input child: targetActor = @actors.messages (layout-chat convention)
-			if (namekey === 'input' && base['@actors'].messages) {
-				base.targetActor = base['@actors'].messages
-			}
-			// When messages child: targetInput = @actors.input (layout-chat convention)
-			if (namekey === 'messages' && base['@actors'].input) {
-				base.targetInput = base['@actors'].input
-			}
-		}
-		return new ReactiveStore(base)
+	_createFallbackContext() {
+		return new ReactiveStore({})
 	}
 
 	/**
@@ -267,11 +250,9 @@ export class ViewEngine {
 	 * Self-healing: when context CoValue fails to load, uses fallback store so actor spawns (no hard failure).
 	 * @param {Object} actorConfig - Actor config
 	 * @param {string} actorId - Actor ID
-	 * @param {Object|null} parentActor - Parent actor when spawning child (for fallback @actors)
-	 * @param {string|null} namekey - Child slot name when spawned (e.g. 'input' for targetActor)
 	 * @returns {Promise<{viewDef, context, contextCoId, contextFactoryCoId, configUnsubscribes}>}
 	 */
-	async loadViewConfigs(actorConfig, actorId, parentActor = null, namekey = null) {
+	async loadViewConfigs(actorConfig, actorId) {
 		if (!actorConfig.view) throw new Error(`[ViewEngine] Actor config must have 'view' property`)
 		const configUnsubscribes = []
 
@@ -310,7 +291,7 @@ export class ViewEngine {
 				retries: 5,
 			})
 			if (!loaded.store) {
-				context = this._createFallbackContext(parentActor, namekey)
+				context = this._createFallbackContext()
 			} else {
 				context = loaded.store
 				contextCoId = loaded.coId
@@ -353,18 +334,10 @@ export class ViewEngine {
 	 * @param {string|null} vibeKey - Optional vibe key
 	 * @param {() => Promise<void>} [onBeforeRender] - Callback before render (e.g. state init)
 	 */
-	async attachViewToActor(
-		actor,
-		containerElement,
-		actorConfig,
-		vibeKey,
-		onBeforeRender,
-		parentActor = null,
-		namekey = null,
-	) {
+	async attachViewToActor(actor, containerElement, actorConfig, vibeKey, onBeforeRender) {
 		const actorId = actor.id
 		const { viewDef, context, contextCoId, contextFactoryCoId, configUnsubscribes } =
-			await this.loadViewConfigs(actorConfig, actorId, parentActor, namekey)
+			await this.loadViewConfigs(actorConfig, actorId)
 
 		actor.shadowRoot = containerElement.attachShadow({ mode: 'open' })
 		actor.context = context
@@ -685,26 +658,20 @@ export class ViewEngine {
 			return
 		}
 
-		let namekey
-		if (typeof slotValue === 'string' && slotValue.startsWith('@')) {
-			namekey = slotValue.slice(1)
-		} else {
+		// Runtime uses co-ids exclusively. Non-co-id values render as plain text.
+		if (typeof slotValue !== 'string' || !slotValue.startsWith('co_z')) {
 			wrapperElement.textContent = String(slotValue)
 			return
 		}
 
 		const actor = this.actorOps?.getActor?.(actorId)
+		if (!actor) return
 
-		if (!actor) {
-			return
-		}
-
-		let childActor = actor.children?.[namekey]
-
+		let childActor = actor.children?.[slotValue]
 		if (!childActor) {
-			childActor = await this.actorOps?._createChildActorIfNeeded?.(
+			childActor = await this.actorOps?._createChildActorByCoId?.(
 				actor,
-				namekey,
+				slotValue,
 				actor.vibeKey ?? null,
 			)
 			if (!childActor) return
@@ -712,10 +679,9 @@ export class ViewEngine {
 
 		if (childActor.containerElement) {
 			// Only destroy children that were previously in THIS slot (same wrapper)
-			// Keeps sibling actors in other slots (e.g. paper + messages in chat)
 			if (actor?.children) {
 				for (const [key, child] of Object.entries(actor.children)) {
-					if (key === namekey) continue
+					if (child === childActor) continue
 					if (child.viewDef && child.containerElement?.parentNode === wrapperElement) {
 						this.runtime?.destroyActor?.(child.id) ?? this.actorOps?.destroyActor?.(child.id)
 						delete actor.children[key]

--- a/libs/maia-engines/src/utils/resolve-helpers.js
+++ b/libs/maia-engines/src/utils/resolve-helpers.js
@@ -79,16 +79,16 @@ export async function resolveSchemaFromCoValue(peer, coId) {
 }
 
 /**
- * Load context store by ref. Resolves ref to co-id, reads store, gets schema.
+ * Load context store by co-id. Runtime uses co-ids exclusively; refs must be transformed during seeding.
  * @param {Object} dataEngine - DataEngine with peer
- * @param {string} ref - Context ref (co-id or namekey)
+ * @param {string} ref - Context co-id (co_z...)
  * @param {Object} [options] - { waitForStoreReadyMs, ensureLoaded, retries }
  * @returns {Promise<{store: Object|null, coId: string|null, factoryCoId: string|null}>}
  */
 export async function loadContextStore(dataEngine, ref, options = {}) {
+	if (!ref?.startsWith('co_z')) return { store: null, coId: null, factoryCoId: null }
 	const peer = dataEngine?.peer
-	const coId = ref?.startsWith('co_z') ? ref : await resolveToCoId(peer, ref)
-	if (!coId) return { store: null, coId: null, factoryCoId: null }
+	const coId = ref
 
 	if (options.ensureLoaded && peer) {
 		await ensureCoValueLoaded(peer, coId, options.ensureLoaded).catch(() => {})

--- a/libs/maia-factories/src/factory-transformer.js
+++ b/libs/maia-factories/src/factory-transformer.js
@@ -20,10 +20,32 @@ function inferRefType(ref) {
 	return null
 }
 
+/**
+ * @namekey pattern: value "@xyz" resolves via @actors.xyz (e.g. actor: "@addForm" -> @actors.addForm).
+ * Simple namekeys have no slashes; skip @inputValue, @todos/intent (labels/dom markers).
+ */
+function isActorNamekey(value) {
+	return (
+		typeof value === 'string' &&
+		value.startsWith('@') &&
+		!value.includes('/') &&
+		value !== '@inputValue' &&
+		value !== '@dataColumn' &&
+		value !== '@fileFromInput' &&
+		value !== '@contentEditableValue' &&
+		value !== '@scope' &&
+		!value.startsWith('@inputByName:')
+	)
+}
+
 /** Generic recursive walker: transform any @/° string ref to co-id. Mutates in place. */
-function walkAndTransformRefs(obj, coIdMap, options = {}) {
+function walkAndTransformRefs(obj, coIdMap, options = {}, ancestorActors = null) {
 	const { throwOnMissing = true } = options
 	if (!obj || typeof obj !== 'object') return
+
+	// Use current @actors or inherit from ancestor (for nested tabs, etc.)
+	const actors =
+		obj['@actors'] && typeof obj['@actors'] === 'object' ? obj['@actors'] : ancestorActors
 
 	if (Array.isArray(obj)) {
 		for (let i = 0; i < obj.length; i++) {
@@ -39,7 +61,7 @@ function walkAndTransformRefs(obj, coIdMap, options = {}) {
 				else if (throwOnMissing)
 					throw new Error(`[SchemaTransformer] No co-id found for array ref: ${item}`)
 			} else if (item && typeof item === 'object') {
-				walkAndTransformRefs(item, coIdMap, options)
+				walkAndTransformRefs(item, coIdMap, options, actors)
 			}
 		}
 		return
@@ -71,7 +93,10 @@ function walkAndTransformRefs(obj, coIdMap, options = {}) {
 	}
 
 	for (const [key, value] of Object.entries(obj)) {
-		if (key.startsWith('$') && key !== '$co' && key !== '$factory' && key !== '$id') continue
+		// Skip $ keys except $co, $factory (refs to transform). $id is instance identifier, not a ref.
+		if (key.startsWith('$') && key !== '$co' && key !== '$factory') continue
+		// @label holds human-readable display labels (e.g. @todos/intent), not co-id refs
+		if (key === '@label') continue
 
 		if (
 			typeof value === 'string' &&
@@ -79,19 +104,9 @@ function walkAndTransformRefs(obj, coIdMap, options = {}) {
 			!value.startsWith('co_z')
 		) {
 			let refToTransform = value
-			if (
-				value.startsWith('@') &&
-				(key === 'target' ||
-					key === 'targetActor' ||
-					key === 'targetInput' ||
-					key === 'targetMessages' ||
-					key === 'targetInfoCard' ||
-					key === 'paperService' ||
-					key === 'contentService') &&
-				obj['@actors'] &&
-				typeof obj['@actors'][value.slice(1)] === 'string'
-			) {
-				refToTransform = obj['@actors'][value.slice(1)]
+			// @namekey (e.g. @addForm) resolves via @actors - use current or ancestor
+			if (isActorNamekey(value) && actors && typeof actors[value.slice(1)] === 'string') {
+				refToTransform = actors[value.slice(1)]
 			}
 			const type = key === 'factory' ? 'schema' : (inferRefType(refToTransform) ?? 'target')
 			const coId = refToTransform.startsWith('co_z')
@@ -101,7 +116,7 @@ function walkAndTransformRefs(obj, coIdMap, options = {}) {
 			else if (throwOnMissing)
 				throw new Error(`[SchemaTransformer] No co-id found for ${key}: ${refToTransform}`)
 		} else if (value && typeof value === 'object') {
-			walkAndTransformRefs(value, coIdMap, options)
+			walkAndTransformRefs(value, coIdMap, options, actors)
 		}
 	}
 }


### PR DESCRIPTION
Removes all runtime @namekey resolution fallbacks so that only co-id references are used at runtime.

**Changes:**
- view.engine: `_renderSlot` only accepts `co_z` strings, remove @namekey branch
- view.engine: `_createFallbackContext` returns empty store, drop namekey params
- actor.engine: delete `_createChildActorIfNeeded`, use `_createChildActorByCoId` only
- actor.engine: `createActor` drops parentActor/namekey params
- resolve-helpers: `loadContextStore` requires co_z refs only
- data.engine: `readFactoryOp` and `createOp` require co-id factory params
- docs: update references to `_createChildActorByCoId`