### PR TITLE
[chore] version-tag: unpadded month/day in release tag (GNU date)

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Generate version
         id: version
         run: |
-          VERSION=$(date -u +%y.%m.%d%H%M)
+          # GNU date (ubuntu-latest): %-m / %-d avoid zero-padding month/day; tag/commit match sync-version output.
+          VERSION=$(date -u +%y.%-m.%-d%H%M)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Generated version: $VERSION"
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -9,8 +9,8 @@
  * - services/app/src-tauri/tauri.conf.json (version)
  *
  * CI tag format: YY.MM.DDHHMM (UTC) — year, month, then day + hour + minute concatenated
- * (e.g. 26.04.021430 = 2026-04-02 14:30 UTC). Leading zeros may appear in segments; npm,
- * Tauri, and Cargo require valid semver, so each segment is normalized (e.g. 26.04.021430 → 26.4.21430).
+ * (e.g. 26.4.21430 = 2026-04-02 14:30 UTC). version-tag uses GNU date %-m / %-d so month/day are not
+ * zero-padded. npm/Tauri/Cargo still need valid semver; each segment is normalized if needed.
  *
  * Triggered automatically on merge to `next` (version-tag workflow).
  * For local use: bun run version:sync <version>

--- a/services/app/src-tauri/tauri.conf.json
+++ b/services/app/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
 		],
 		"security": {
 			"csp": "default-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; connect-src 'self' data: ipc: http://ipc.localhost https: wss: http: ws: tauri://localhost http://tauri.localhost https://tauri.localhost; worker-src 'self' blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; media-src 'self' blob: mediastream:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-			"dangerousDisableAssetCspModification": [
-				"script-src"
-			],
+			"dangerousDisableAssetCspModification": ["script-src"],
 			"headers": {
 				"Cross-Origin-Opener-Policy": "same-origin",
 				"Cross-Origin-Embedder-Policy": "credentialless"
@@ -32,9 +30,7 @@
 	},
 	"bundle": {
 		"active": true,
-		"targets": [
-			"app"
-		],
+		"targets": ["app"],
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",


### PR DESCRIPTION
Aligns generated `VERSION` with `sync-version.js` semver normalization: use GNU `date` `%-m` / `%-d` on ubuntu-latest so release titles and git tags no longer show zero-padded month/day (e.g. `04`, `01`).