### PR TITLE
Promote next to main after release; landing-only CI on main

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -26,7 +26,7 @@ jobs:
         run: bun run check:ci
 
   build:
-    if: github.event_name != 'push' || github.event.head_commit == null || !startsWith(github.event.head_commit.message, '[release] ')
+    if: (github.event_name != 'push' || github.event.head_commit == null || !startsWith(github.event.head_commit.message, '[release] ')) && (github.event_name != 'push' || github.ref != 'refs/heads/main')
     name: Build (app + sync)
     runs-on: ubuntu-latest
     steps:
@@ -50,6 +50,16 @@ jobs:
 
       - name: Build sync (Docker)
         run: docker build -f services/sync/Dockerfile -t sync-build . 2>&1 | tail -30
+
+      - name: Build landing (Docker)
+        run: docker build -f services/landing/Dockerfile -t landing-build . 2>&1 | tail -30
+
+  build-landing-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (github.event.head_commit == null || !startsWith(github.event.head_commit.message, '[release] '))
+    name: Build (landing)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Build landing (Docker)
         run: docker build -f services/landing/Dockerfile -t landing-build . 2>&1 | tail -30

--- a/.github/workflows/promote-next-to-main.yml
+++ b/.github/workflows/promote-next-to-main.yml
@@ -1,0 +1,29 @@
+# After version-tag pushes [release] to `next`, fast-forward `main` to match `next`.
+# Push to `main` triggers deploy-main.yml (landing only).
+
+name: Promote next to main
+
+on:
+  push:
+    branches: [next]
+
+jobs:
+  promote:
+    if: github.event.head_commit != null && startsWith(github.event.head_commit.message, '[release] ')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Fast-forward main to next
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main next
+          git checkout main
+          git merge --ff-only origin/next
+          git push origin main

--- a/services/app/src-tauri/tauri.conf.json
+++ b/services/app/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
 		],
 		"security": {
 			"csp": "default-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; connect-src 'self' data: ipc: http://ipc.localhost https: wss: http: ws: tauri://localhost http://tauri.localhost https://tauri.localhost; worker-src 'self' blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; media-src 'self' blob: mediastream:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-			"dangerousDisableAssetCspModification": [
-				"script-src"
-			],
+			"dangerousDisableAssetCspModification": ["script-src"],
 			"headers": {
 				"Cross-Origin-Opener-Policy": "same-origin",
 				"Cross-Origin-Embedder-Policy": "credentialless"
@@ -32,9 +30,7 @@
 	},
 	"bundle": {
 		"active": true,
-		"targets": [
-			"app"
-		],
+		"targets": ["app"],
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",


### PR DESCRIPTION
Adds `promote-next-to-main.yml`: on `[release]` push to `next`, fast-forwards `main` to match `next` (uses `DEPLOY_KEY`). Updates `biome.yml`: full Docker build skips pushes to `main`; new `Build (landing)` job for `main` pushes only.

**GitHub (manual):** Allow deploy key bypass on protected `main`; set required status `Build (landing)` for `main` if you use branch protection.