### PR TITLE
[fix] Promote workflow: merge next into main when not fast-forwardable

### DIFF
--- a/.github/workflows/promote-next-to-main.yml
+++ b/.github/workflows/promote-next-to-main.yml
@@ -1,4 +1,5 @@
-# After version-tag pushes [release] to `next`, fast-forward `main` to match `next`.
+# After version-tag pushes [release] to `next`, merge `next` into `main`.
+# Uses a regular merge (not --ff-only) so promotion still works if branches diverged.
 # Push to `main` triggers deploy-main.yml (landing only).
 
 name: Promote next to main
@@ -19,11 +20,11 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Fast-forward main to next
+      - name: Merge next into main
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main next
           git checkout main
-          git merge --ff-only origin/next
+          git merge origin/next -m "[chore] promote next after release"
           git push origin main

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -6,7 +6,7 @@
  * Updates:
  * - All services/* and libs/* package.json files
  * - services/app/src-tauri/Cargo.toml ([package] version)
- * - services/app/src-tauri/tauri.conf.json (version)
+ * - services/app/src-tauri/tauri.conf.json (version line only — preserves Biome formatting; never full JSON.stringify)
  *
  * CI tag format: YY.MM.DDHHMM (UTC) — year, month, then day + hour + minute concatenated
  * (e.g. 26.4.21430 = 2026-04-02 14:30 UTC). version-tag uses GNU date %-m / %-d so month/day are not
@@ -93,12 +93,19 @@ try {
 
 const tauriConfPath = join(rootDir, 'services/app/src-tauri/tauri.conf.json')
 try {
-	const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf-8'))
-	tauriConf.version = newVersion
-	writeFileSync(tauriConfPath, `${JSON.stringify(tauriConf, null, '\t')}\n`)
+	const raw = readFileSync(tauriConfPath, 'utf-8')
+	if (!/^(\s*"version"\s*:\s*)"[^"]*"/m.test(raw)) {
+		throw new Error('Could not update version in tauri.conf.json (missing root "version" key)')
+	}
+	const next = raw.replace(/^(\s*"version"\s*:\s*)"[^"]*"/m, `$1"${newVersion}"`)
+	writeFileSync(tauriConfPath, next)
 	console.log(`  ${tauriConfPath.replace(`${rootDir}/`, '')}`)
-} catch {
-	// Optional
+} catch (err) {
+	if (err?.code === 'ENOENT') {
+		// Optional workspace layout
+	} else {
+		throw err
+	}
 }
 
 console.log(`Version ${newVersion} synced.`)

--- a/services/app/src-tauri/tauri.conf.json
+++ b/services/app/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
 		],
 		"security": {
 			"csp": "default-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; connect-src 'self' data: ipc: http://ipc.localhost https: wss: http: ws: tauri://localhost http://tauri.localhost https://tauri.localhost; worker-src 'self' blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; media-src 'self' blob: mediastream:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-			"dangerousDisableAssetCspModification": [
-				"script-src"
-			],
+			"dangerousDisableAssetCspModification": ["script-src"],
 			"headers": {
 				"Cross-Origin-Opener-Policy": "same-origin",
 				"Cross-Origin-Embedder-Policy": "credentialless"
@@ -32,9 +30,7 @@
 	},
 	"bundle": {
 		"active": true,
-		"targets": [
-			"app"
-		],
+		"targets": ["app"],
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",


### PR DESCRIPTION
Replaces `git merge --ff-only` with a normal `git merge origin/next` so promotion succeeds after `main` and `next` have diverged (e.g. before initial alignment). After `main` tracks `next`, merges are often still fast-forward; otherwise a merge commit is created.

Conflict resolution still requires a manual merge if Git cannot auto-merge.