### PR TITLE
[feat] Semver -next prerelease for next branch; GitHub prerelease releases

### DIFF
--- a/.cursor/rules/continous-versioning.mdc
+++ b/.cursor/rules/continous-versioning.mdc
@@ -16,7 +16,7 @@ alwaysApply: true
 
 Example: `26.04.021430` = 2 Apr 2026, 14:30 UTC.
 
-**Stored version:** `sync-version.js` writes one **semver-normalized** string everywhere (leading zeros removed per segment), e.g. `26.04.021430` → `26.4.21430`. Same rule for npm, Tauri, and Cargo.
+**Stored version:** `sync-version.js` writes one **semver-normalized** string everywhere (leading zeros removed per core segment). Releases from `next` use a **prerelease** suffix: `26.04.021430-next` → `26.4.21430-next`. Stable promotion (e.g. `main`) can sync without `-next` when you cut production. Same rule for npm, Tauri, and Cargo.
 
 ### Scope
 

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -27,7 +27,8 @@ jobs:
         id: version
         run: |
           # GNU date (ubuntu-latest): %-m / %-d avoid zero-padding month/day; tag/commit match sync-version output.
-          VERSION=$(date -u +%y.%-m.%-d%H%M)
+          CORE=$(date -u +%y.%-m.%-d%H%M)
+          VERSION="${CORE}-next"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Generated version: $VERSION"
 
@@ -50,5 +51,6 @@ jobs:
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"
           gh release create "v${{ steps.version.outputs.version }}" \
+            --prerelease \
             --title "v${{ steps.version.outputs.version }}" \
-            --notes "Auto-generated release from merge to next"
+            --notes "Prerelease (\`-next\`) from merge to \`next\`. Production \`main\` is promoted separately when ready."

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -12,9 +12,13 @@
  * (e.g. 26.4.21430 = 2026-04-02 14:30 UTC). version-tag uses GNU date %-m / %-d so month/day are not
  * zero-padded. npm/Tauri/Cargo still need valid semver; each segment is normalized if needed.
  *
+ * Optional semver prerelease after the core (e.g. `-next` for `next` branch releases):
+ * `26.04.021430-next` → `26.4.21430-next`.
+ *
  * Triggered automatically on merge to `next` (version-tag workflow).
  * For local use: bun run version:sync <version>
  * Example: bun run version:sync 26.04.021430
+ * Example (prerelease): bun run version:sync 26.04.021430-next
  */
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
@@ -31,13 +35,28 @@ if (!rawVersion) {
 	exit(1)
 }
 
-/** Valid semver for npm, Tauri, Cargo: strip leading zeros per segment. */
+/** Valid semver for npm, Tauri, Cargo: strip leading zeros per core segment; keep optional prerelease (e.g. `-next`). */
 function toSemverVersion(continuous) {
-	const parts = continuous.split('.')
-	if (parts.length !== 3) {
-		throw new Error(`Expected YY.MM.DDHHMM (three dot parts), got: ${continuous}`)
+	const trimmed = continuous.trim()
+	const dashIdx = trimmed.indexOf('-')
+	if (dashIdx === -1) {
+		const parts = trimmed.split('.')
+		if (parts.length !== 3) {
+			throw new Error(`Expected YY.MM.DDHHMM (three dot parts), got: ${continuous}`)
+		}
+		return parts.map((p) => String(Number.parseInt(p, 10))).join('.')
 	}
-	return parts.map((p) => String(Number.parseInt(p, 10))).join('.')
+	const core = trimmed.slice(0, dashIdx)
+	const prerelease = trimmed.slice(dashIdx + 1)
+	if (!prerelease) {
+		throw new Error(`Invalid prerelease in: ${continuous}`)
+	}
+	const parts = core.split('.')
+	if (parts.length !== 3) {
+		throw new Error(`Expected YY.MM.DDHHMM before '-', got: ${continuous}`)
+	}
+	const normalizedCore = parts.map((p) => String(Number.parseInt(p, 10))).join('.')
+	return `${normalizedCore}-${prerelease}`
 }
 
 const newVersion = toSemverVersion(rawVersion)


### PR DESCRIPTION
- **version-tag.yml:** append `-next` to the continuous version; tags/releases are `vYY.M.DDHHMM-next`; GitHub release stays `--prerelease`.
- **sync-version.js:** `toSemverVersion` accepts optional prerelease (e.g. `26.04.021430-next` → `26.4.21430-next`); stable sync without `-next` unchanged.
- **continous-versioning.mdc:** documents the `-next` convention.