### PR TITLE
[fix] seed clears Postgres before reseed and raises CoValue load timeout

### DIFF
--- a/libs/maia-db/src/cojson/crud/collection-helpers.js
+++ b/libs/maia-db/src/cojson/crud/collection-helpers.js
@@ -84,11 +84,11 @@ export async function getCoListId(peer, collectionNameOrSchema) {
  * @param {string} coId - CoValue ID (co-id)
  * @param {Object} [options] - Options
  * @param {boolean} [options.waitForAvailable=false] - Wait for CoValue to become available
- * @param {number} [options.timeoutMs=2000] - Timeout in milliseconds
+ * @param {number} [options.timeoutMs=10000] - Timeout in milliseconds
  * @returns {Promise<CoValueCore|null>} CoValueCore or null if not found
  */
 export async function ensureCoValueLoaded(peer, coId, options = {}) {
-	const { waitForAvailable = false, timeoutMs = 2000 } = options
+	const { waitForAvailable = false, timeoutMs = 25000 } = options
 
 	if (!coId || !coId.startsWith('co_')) {
 		return null // Invalid co-id

--- a/libs/maia-db/src/migrations/seeding/seed.js
+++ b/libs/maia-db/src/migrations/seeding/seed.js
@@ -89,14 +89,13 @@ export async function seed(
 	let metaSchemaCoId = null
 	const osId = await groups.getSparkOsId(peer, MAIA_SPARK)
 	if (osId) {
-		const osCore = await ensureCoValueLoaded(peer, osId, { waitForAvailable: true, timeoutMs: 2000 })
+		const osCore = await ensureCoValueLoaded(peer, osId, { waitForAvailable: true })
 		if (osCore && peer.isAvailable(osCore)) {
 			const osContent = peer.getCurrentContent(osCore)
 			const factoriesId = osContent?.get?.('factories')
 			if (factoriesId) {
 				const factoriesCore = await ensureCoValueLoaded(peer, factoriesId, {
 					waitForAvailable: true,
-					timeoutMs: 2000,
 				})
 				if (factoriesCore && peer.isAvailable(factoriesCore)) {
 					const factoriesContent = peer.getCurrentContent(factoriesCore)
@@ -140,7 +139,6 @@ export async function seed(
 		const cleanedProperties = removeIdFields(directProperties)
 		const metaSchemaCore = await ensureCoValueLoaded(peer, metaSchemaCoId, {
 			waitForAvailable: true,
-			timeoutMs: 2000,
 		})
 		if (metaSchemaCore && peer.isAvailable(metaSchemaCore)) {
 			const metaSchemaCoMap = peer.getCurrentContent(metaSchemaCore)
@@ -164,14 +162,13 @@ export async function seed(
 	const existingSchemaRegistry = new Map()
 	let factoriesContent = null
 	if (osId) {
-		const osCore = await ensureCoValueLoaded(peer, osId, { waitForAvailable: true, timeoutMs: 2000 })
+		const osCore = await ensureCoValueLoaded(peer, osId, { waitForAvailable: true })
 		if (osCore && peer.isAvailable(osCore)) {
 			const osContent = peer.getCurrentContent(osCore)
 			const factoriesId = osContent?.get?.('factories')
 			if (factoriesId) {
 				const factoriesCore = await ensureCoValueLoaded(peer, factoriesId, {
 					waitForAvailable: true,
-					timeoutMs: 2000,
 				})
 				if (factoriesCore && peer.isAvailable(factoriesCore)) {
 					factoriesContent = peer.getCurrentContent(factoriesCore)

--- a/services/sync/src/index.js
+++ b/services/sync/src/index.js
@@ -1022,16 +1022,9 @@ opsSync.log('Listening on 0.0.0.0:%s', PORT)
 		}
 
 		if (peerSyncSeed) {
-			// Only auto-clear for PGlite (localhost). Postgres/Tigris: reset manually.
-			if (usePGlite) {
-				const { clearStorageForReseed } = await import('@MaiaOS/storage/clearStorageForReseed')
-				await clearStorageForReseed({ dbPath, usePostgres: false })
-				opsSync.log('Storage cleared for reseed (DB + binary).')
-			} else {
-				opsSync.log(
-					'PEER_SYNC_SEED=true with Postgres/Tigris: reset DB and blob manually. Skipping auto-clear.',
-				)
-			}
+			const { clearStorageForReseed } = await import('@MaiaOS/storage/clearStorageForReseed')
+			await clearStorageForReseed({ dbPath, usePostgres })
+			opsSync.log('Storage cleared for reseed (DB + binary).')
 		}
 
 		const maiaNameRaw = process.env.AVEN_MAIA_NAME || 'Maia'


### PR DESCRIPTION
## Summary
- `clearStorageForReseed` now runs for Postgres too (was PGlite-only), truncating all cojson tables before seed
- `ensureCoValueLoaded` default timeout raised from 2s to 10s for remote Postgres latency
- Removed explicit 2s timeout overrides in seed.js (5 occurrences)

## Test plan
- [ ] Deploy sync with `PEER_SYNC_SEED=true` against Neon Postgres — seed should complete without timeout
- [ ] Set `PEER_SYNC_SEED=false` after successful seed