### PR TITLE
[fix] quieter sync logs: Postgres SSL, serial queries, bootstrap noise

### DIFF
--- a/.cursor/rules/monorepo-architecture.mdc
+++ b/.cursor/rules/monorepo-architecture.mdc
@@ -33,16 +33,16 @@ MaiaOS/ (root)
 
 ## Workspace Organization
 
-### `services/maia/` - Frontend SPA
+### `services/app/` - Frontend SPA
 - **Port 4200** (dev)
 - Bun-built SPA, pure static server (no proxy)
-- Client connects directly to moai (4201) for sync/API — CORS enabled on moai
-- Sync domain: `VITE_PEER_MOAI` at build time (fly.toml [build.args])
+- Client connects directly to sync (4201) for sync/API — CORS enabled on the sync server
+- Sync host: `VITE_PEER_SYNC_HOST` at build time (fly.toml [build.args])
 
-### `services/moai/` - Sync + API
+### `services/sync/` - Sync + API
 - **Port 4201** (dev)
 - Unified: WebSocket sync (cojson LocalNode), agent API, LLM proxy
-- Secrets: `PEER_ID`, `PEER_SECRET`, `RED_PILL_API_KEY`, etc. (no PEER_MOAI for maia deploy)
+- Secrets: `PEER_ID`, `PEER_SECRET`, `RED_PILL_API_KEY`, etc.
 
 ### `libs/` - Shared Libraries
 Reusable packages that can be shared across multiple workspaces:
@@ -179,8 +179,8 @@ bun run build                  # Build sync
 
 Each workspace builds independently:
 ```bash
-cd services/maia && bun run build       # Build maia (Bun, uses distros bundles)
-cd services/moai && bun run build      # Build moai
+cd services/app && bun run build        # Build app (Bun, uses distros bundles)
+cd services/sync && bun run build       # Build sync
 cd libs/maia-distros && bun run build   # Build bundles (client, server, vibes)
 ```
 
@@ -250,7 +250,7 @@ Each service in the monorepo has a **hardcoded development port** to avoid confl
 MaiaOS/
 ├── .env                    # Root-level env vars (all services/libs)
 ├── services/
-│   └── maia/
+│   └── app/
 │       └── .env.local      # Optional: service-specific overrides (gitignored)
 └── libs/
     └── [lib]/
@@ -284,12 +284,12 @@ bun install
 # Run development server (from root)
 bun dev
 
-# Build maia (from services/maia)
-cd services/maia && bun run build
+# Build app (from services/app)
+cd services/app && bun run build
 
 
-# Add dependency to maia
-cd services/maia && bun add <package>
+# Add dependency to app
+cd services/app && bun add <package>
 
 # Add dependency to shared library
 cd libs/maia-db && bun add <package>

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,8 @@ libs/maia-distros/output/
 # maia-vibes dist (build output, not used in dev - we use source)
 libs/maia-vibes/dist/
 
+# maia-game bundled terrain worker (built by build:terrain-worker or app build.js)
+libs/maia-game/dist/
+
 # Cursor / agent skills local lock (optional tooling output)
 skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ vite.config.ts.timestamp-*
 **/zero-replica.db*
 **/*.db-journal
 
-# PGlite local dev data (moai sync server - never commit)
+# PGlite local dev data (sync server — never commit)
 **/pgdata/
 pg-lite.db
 **/pg-lite.db

--- a/libs/maia-actors/src/os/ai/function.js
+++ b/libs/maia-actors/src/os/ai/function.js
@@ -1,9 +1,9 @@
 /**
  * AI Chat Actor - @ai/chat
  *
- * Unified AI chat using OpenAI-compatible API (RedPill via moai proxy).
+ * Unified AI chat using OpenAI-compatible API (RedPill via sync proxy).
  * LLM loop runs client-side: Runtime.collectTools + Runtime.executeToolCall.
- * Moai is LLM proxy only (no tool execution).
+ * Sync is LLM proxy only (no tool execution).
  *
  * Usage in process:
  *   {"actor": "@ai/chat", "payload": {"context": [...], "model": "qwen/..."}}

--- a/libs/maia-actors/src/seed-config.js
+++ b/libs/maia-actors/src/seed-config.js
@@ -1,6 +1,6 @@
 /**
  * Seed config for service actors - contributes actors to genesis seed.
- * Merged by moai into buildSeedConfig output; replaces separate tool config.
+ * Merged by the sync server into buildSeedConfig output; replaces separate tool config.
  * Also includes standalone UI actors (e.g. placeholder).
  */
 

--- a/libs/maia-db/src/cojson/crud/process-inbox.js
+++ b/libs/maia-db/src/cojson/crud/process-inbox.js
@@ -60,8 +60,8 @@ export async function processInbox(peer, actorId, inboxCoId) {
 	if (!inboxData?.sessions) {
 		return { messages: [] }
 	}
-	// CRITICAL: Process ALL sessions - client must see server replies (e.g. SUCCESS from aiChat on moai)
-	// Session-only processing caused: maia never saw SUCCESS (moai's session) → result: null, no LLM response
+	// CRITICAL: Process ALL sessions - client must see server replies (e.g. SUCCESS from aiChat on sync)
+	// Session-only processing caused: app never saw SUCCESS (sync session) → result: null, no LLM response
 	const allItems = []
 	for (const items of Object.values(inboxData.sessions || {})) {
 		if (Array.isArray(items)) allItems.push(...items)

--- a/libs/maia-db/src/cojson/helpers/resolve-account-profile.js
+++ b/libs/maia-db/src/cojson/helpers/resolve-account-profile.js
@@ -97,14 +97,43 @@ async function resolveAccountToProfileCoIdViaAvens(maia, accountCoId) {
 }
 
 /**
+ * Signed-in user: profile co-id is on the live account — do not walk registries (those stores
+ * often stay `loading` until sync settles and each waitForStore can burn the full 5s timeout).
+ */
+async function resolveSelfAccountProfileFromLiveAccount(maia, accountCoId) {
+	const acc = maia?.id?.maiaId
+	const selfId = acc?.id ?? acc?.$jazz?.id
+	if (selfId !== accountCoId || typeof acc?.get !== 'function') return null
+	const profileCoId = acc.get('profile')
+	if (!profileCoId?.startsWith('co_z')) return null
+	const profileStore = await maia.do({ op: 'read', factory: null, key: profileCoId })
+	await waitForStore(profileStore, 5000)
+	const profileData = profileStore?.value ?? profileStore
+	const name = profileData?.name
+	const image =
+		typeof profileData?.avatar === 'string' && profileData.avatar.startsWith('co_z')
+			? profileData.avatar
+			: null
+	return {
+		id: profileCoId,
+		name: typeof name === 'string' && name.length > 0 ? name : travelerFallback(accountCoId),
+		image,
+	}
+}
+
+/**
  * Resolve a single account co-id to profile id, name, and image
- * Uses humans registry (public) first; falls back to account read for self.
+ * Self account: read profile from live account first (avoids registries wait chain).
+ * Others: humans registry, then avens, then @account read.
  * @param {Object} maia - MaiaOS instance with maia.do()
  * @param {string} accountCoId - Account co-id (co_z...)
  * @returns {Promise<{ id: string|null, name: string, image: string|null }>}
  */
 async function resolveOneToProfile(maia, accountCoId) {
 	try {
+		const selfProfile = await resolveSelfAccountProfileFromLiveAccount(maia, accountCoId)
+		if (selfProfile) return selfProfile
+
 		let profileCoId = await resolveAccountToProfileCoIdViaHumans(maia, accountCoId)
 		if (!profileCoId) {
 			profileCoId = await resolveAccountToProfileCoIdViaAvens(maia, accountCoId)

--- a/libs/maia-db/src/cojson/indexing/factory-index-manager.js
+++ b/libs/maia-db/src/cojson/indexing/factory-index-manager.js
@@ -20,6 +20,8 @@ import * as groups from '../groups/groups.js'
 // Matches both °Spark/schema/... and @domain/schema/... (captures prefix + path)
 const SCHEMA_REF_MATCH = /^([°@][a-zA-Z0-9_-]+)\/factory\/(.+)$/
 
+let warnedRegistriesMissingDuringBootstrap = false
+
 /**
  * Ensure spark.os CoMap exists (account.registries.sparks[spark].os)
  * @param {Object} peer - Backend instance
@@ -71,9 +73,12 @@ async function ensureOsCoMap(peer, spark) {
 
 	const registriesId = peer.account?.get?.('registries')
 	if (!registriesId?.startsWith('co_z')) {
-		console.error(
-			'[SchemaIndexManager] account.registries not set. Indexing requires linkAccountToRegistries.',
-		)
+		if (!warnedRegistriesMissingDuringBootstrap) {
+			warnedRegistriesMissingDuringBootstrap = true
+			console.warn(
+				'[SchemaIndexManager] account.registries not set yet (bootstrap). Indexing deferred until linkAccountToRegistries.',
+			)
+		}
 	}
 	return null
 }

--- a/libs/maia-docs/01_getting-started/02-architecture.md
+++ b/libs/maia-docs/01_getting-started/02-architecture.md
@@ -364,7 +364,7 @@ MaiaOS/
 │   └── maia-self/              # Self-sovereign identity
 └── services/
     ├── maia/                   # Frontend SPA
-    └── moai/                   # Sync + API
+    └── sync/                   # Sync + API
 ```
 
 ## Key Architectural Patterns

--- a/libs/maia-docs/03_developers/02_maia-loader/api-reference.md
+++ b/libs/maia-docs/03_developers/02_maia-loader/api-reference.md
@@ -6,7 +6,7 @@ Complete API reference for `@MaiaOS/loader` package.
 
 ## Re-exports (single-entry pattern)
 
-Services (maia, moai) import only from `@MaiaOS/loader`. Loader re-exports everything needed:
+Services (app, sync) import only from `@MaiaOS/loader`. Loader re-exports everything needed:
 
 | Export | Source | Use |
 |--------|--------|-----|
@@ -32,7 +32,7 @@ Boots the MaiaOS operating system. Authentication is integrated into boot—you 
 - `config.agentSecret` (optional) - Agent secret for UCAN/capability tokens
 - `config.modules` (optional, default: `['db', 'core']`) - Modules to load (db, core, ai)
 - `config.syncDomain` (optional) - Sync server domain
-- `config.getMoaiBaseUrl` (optional) - Base URL for moai sync server
+- `config.getMoaiBaseUrl` (optional) - Base URL for the sync server
 - `config.isDevelopment` (optional) - Development mode flag
 - `config.runtimeType` (optional, default: `'browser'`) - Runtime type
 

--- a/libs/maia-docs/03_developers/05_maia-db/seeding.md
+++ b/libs/maia-docs/03_developers/05_maia-db/seeding.md
@@ -25,7 +25,7 @@ Think of seeding like setting up a new house. First you install the plumbing (bo
 **Re-seed when actor, process, view, or context configs change.** Runtime expects all config references to be co-ids. Refs are transformed to co-ids only during seeding. If you modify `.maia` files (actors, processes, views, contexts) or the seed config, run with `PEER_FRESH_SEED=true` before testing. Otherwise the app may fail with "Expected co-id, got ref" or process load errors.
 
 ```bash
-PEER_FRESH_SEED=true bun dev:moai
+PEER_FRESH_SEED=true bun dev:sync
 ```
 
 ---

--- a/libs/maia-docs/03_developers/09_deployment/README.md
+++ b/libs/maia-docs/03_developers/09_deployment/README.md
@@ -2,5 +2,5 @@
 
 **Single source of truth** for MaiaOS Fly.io deployment. Replaces service-level DEPLOY.md and README-FLY.md.
 
-- [Deployment Guide](./deployment-guide.md) - Complete guide: Fly.io setup, maia + moai deploy, DNS (Hetzner), volumes, secrets, troubleshooting
+- [Deployment Guide](./deployment-guide.md) - Complete guide: Fly.io setup, app + sync deploy, DNS (Hetzner), volumes, secrets, troubleshooting
 - [Tigris Blob Storage](./tigris-blob-storage.md) - Provision Tigris object storage for binary CoValues (images, files) on sync-next-maia-city

--- a/libs/maia-docs/03_developers/09_deployment/deployment-guide.md
+++ b/libs/maia-docs/03_developers/09_deployment/deployment-guide.md
@@ -1,6 +1,6 @@
 # MaiaOS Production Deployment Guide
 
-Complete guide for deploying MaiaOS services to Fly.io, including DNS setup. Consolidates maia and moai deployment documentation.
+Complete guide for deploying MaiaOS services to Fly.io, including DNS setup. Consolidates app and sync deployment documentation.
 
 ## Prerequisites
 
@@ -129,7 +129,7 @@ flyctl apps destroy sync-next-maia-city
 ### Fly.io Domains (Default)
 
 - **Frontend**: `https://next-maia-city.fly.dev`
-- **Moai**: `https://moai-next-maia-city.fly.dev`
+- **Sync** (Fly app `moai-next-maia-city`): `https://moai-next-maia-city.fly.dev`
 
 ### Custom Domains
 
@@ -297,7 +297,7 @@ curl https://next-maia-city.fly.dev/
 
 ## WebSocket Endpoint
 
-Clients connect to moai sync via:
+Clients connect to the sync service via:
 - **Fly.io:** `wss://moai-next-maia-city.fly.dev/sync`
 - **Custom domain:** `wss://sync.next.maia.city/sync`
 
@@ -343,7 +343,7 @@ The API (LLM chat) and sync use the same domain. Sync domain comes from `VITE_PE
 
 ### Frontend can't connect to server
 
-1. Verify fly.toml [build.args] VITE_PEER_SYNC_HOST matches your moai domain
+1. Verify fly.toml [build.args] VITE_PEER_SYNC_HOST matches your sync host
 2. Check sync service is running: `curl https://moai-next-maia-city.fly.dev/health`
 3. Verify DNS/domain configuration if using custom domains
 
@@ -352,7 +352,7 @@ The API (LLM chat) and sync use the same domain. Sync domain comes from `VITE_PE
 1. Check logs: `flyctl logs --app moai-next-maia-city`
 2. Test health: `curl https://moai-next-maia-city.fly.dev/health`
 
-### "The app appears to be crashing" (Moai)
+### "The app appears to be crashing" (sync)
 
 Usually missing secrets. Run:
 ```bash
@@ -361,7 +361,7 @@ bun agent:generate
 bun run deploy:secrets
 ```
 
-### Volume not mounted (Moai)
+### Volume not mounted (sync)
 
 1. Verify volume exists: `flyctl volumes list --app moai-next-maia-city`
 2. Volume name must match fly.toml [mounts] `source`: `moai_data`
@@ -373,11 +373,11 @@ bun run deploy:secrets
 Both services have deployment scripts:
 
 ```bash
-# Moai (sync+API)
-cd services/moai && bun run deploy
+# Sync (WebSocket + API)
+cd services/sync && bun run deploy
 
-# Maia City
-cd services/maia && bun run deploy
+# App (frontend)
+cd services/app && bun run deploy
 ```
 
 These scripts handle deployment from the monorepo root with proper Dockerfile and config paths.

--- a/libs/maia-docs/03_developers/09_deployment/tigris-blob-storage.md
+++ b/libs/maia-docs/03_developers/09_deployment/tigris-blob-storage.md
@@ -147,7 +147,7 @@ When `BUCKET_NAME` is set, the sync service uses `TigrisBlobStore` (S3). When un
 
 ## Related Documentation
 
-- [Deployment Guide](./deployment-guide.md) - Fly.io setup, moai deploy, DNS, volumes
+- [Deployment Guide](./deployment-guide.md) - Fly.io setup, sync deploy, DNS, volumes
 - [fly-next-setup.md](../../../../scripts/fly-next-setup.md) - Neon + sync-next-maia-city setup (prerequisite)
 - [storage-layer.md](../05_maia-db/storage-layer.md) - Browser storage (OPFS/IndexedDB), server blob offloading
 - [Fly.io Tigris docs](https://fly.io/docs/tigris/)

--- a/libs/maia-docs/03_developers/10_architecture/sync-readiness.md
+++ b/libs/maia-docs/03_developers/10_architecture/sync-readiness.md
@@ -4,9 +4,9 @@ How we ensure the WebSocket client connects successfully on first sign-in, witho
 
 ## Problem
 
-- **moai** (sync server) has async init: PGlite, agent worker, syncHandler. Until ready, `/sync` returns 503.
-- **maia** (client) connects to `ws://localhost:4201/sync` as soon as the app loads.
-- If the client connects before moai is ready → "bad response from server" → noisy error, 3–5s until retry succeeds.
+- **Sync** (port 4201) has async init: PGlite, agent worker, syncHandler. Until ready, `/sync` returns 503.
+- **App** (client) connects to `ws://localhost:4201/sync` as soon as the page loads.
+- If the client connects before sync is ready → "bad response from server" → noisy error, 3–5s until retry succeeds.
 
 ## Design Principle
 
@@ -20,9 +20,9 @@ The client assumes the server is ready when it connects. Orchestration (dev scri
 ┌─────────────────────────────────────────────────────────────────┐
 │  Dev (bun dev)                                                   │
 │                                                                  │
-│  1. Start moai (spawn, async init begins)                        │
+│  1. Start sync (spawn, async init begins)                        │
 │  2. Poll GET /health until ready: true                           │
-│  3. Start maia (user can load page; moai is ready)                │
+│  3. Start app (user can load page; sync is ready)                │
 │                                                                  │
 │  → No client polling. No "bad response" on first load.            │
 └─────────────────────────────────────────────────────────────────┘
@@ -40,7 +40,7 @@ The client assumes the server is ready when it connects. Orchestration (dev scri
 
 ## Components
 
-### 1. Health Endpoint (moai)
+### 1. Health Endpoint (sync)
 
 `GET /health` returns:
 
@@ -54,13 +54,13 @@ The client assumes the server is ready when it connects. Orchestration (dev scri
 ### 2. Dev Orchestration (scripts/dev.js)
 
 ```javascript
-await startMoai()
+await startSync()
 await waitForServiceReady('http://localhost:4201/health')
-await startMaia()
+await startApp()
 ```
 
 - `waitForServiceReady` polls `/health` until `ready: true` or timeout.
-- On timeout: maia still starts; WebSocket retries (existing behavior).
+- On timeout: app still starts; WebSocket retries (existing behavior).
 - Orchestration lives at the dev boundary; no client code changes.
 
 ### 3. Client (sync-peers.js)
@@ -81,7 +81,7 @@ Orchestration (who starts what, when) belongs at process boundaries. The client�
 
 ## Contracts
 
-1. **moai** exposes `/health` with `ready` reflecting sync handler availability.
-2. **dev** ensures maia starts only after moai is ready (or timeout).
+1. **Sync** exposes `/health` with `ready` reflecting sync handler availability.
+2. **dev** ensures the app starts only after sync is ready (or timeout).
 3. **production** uses platform health checks so traffic reaches ready instances only.
 4. **client** connects; retries on failure; no readiness probing.

--- a/libs/maia-docs/03_developers/state-and-persistence.md
+++ b/libs/maia-docs/03_developers/state-and-persistence.md
@@ -72,21 +72,21 @@ The sync service requires persistent storage (never in-memory). Two backends are
 
 **simpleAccountSeed** – No account.sparks. Used for all signups (human + agent). Registries set via linkAccountToRegistries.
 
-**genesisAccountSeed** – Full scaffold + vibes. Only when **PEER_MODE=sync** (moai sync server).
+**genesisAccountSeed** – Full scaffold + vibes. Only when **PEER_MODE=sync** (sync server).
 
 | Trigger | Mode | Behavior |
 |---------|------|----------|
 | **createAccountWithSecret** (human or agent) | simpleAccountSeed | No account.sparks. Vibes come from sync; registries via link. |
-| **Moai PEER_MODE=sync** | genesisAccountSeed | Full scaffold + vibes into sync server account. |
+| **Sync PEER_MODE=sync** | genesisAccountSeed | Full scaffold + vibes into sync server account. |
 | **handleSeed** (agent mode, manual) | genesisAccountSeed | Manual reseed for dev. |
 
-**SEED_VIBES** (moai env) controls which vibes moai seeds when PEER_MODE=sync: `"all"` or comma-separated `"todos,chat,db,sparks,creator"`.
+**SEED_VIBES** (sync server env) controls which vibes are seeded when PEER_MODE=sync: `"all"` or comma-separated `"todos,chat,db,sparks,creator"`.
 
 ---
 
 ## Registries (Humans and Sparks)
 
-Top-level `account.registries` stores human and spark identity mappings. Only the sync agent (moai) seeds it during genesis. Humans and agents link by setting `account.registries` to the sync server's registries co-id.
+Top-level `account.registries` stores human and spark identity mappings. Only the sync agent seeds it during genesis. Humans and agents link by setting `account.registries` to the sync server's registries co-id.
 
 ### Structure
 

--- a/libs/maia-game/package.json
+++ b/libs/maia-game/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"main": "./src/index.js",
 	"scripts": {
+		"build:terrain-worker": "bun scripts/build-terrain-height-worker.mjs",
 		"generate:dome": "bun scripts/generate-dome.mjs",
 		"import:dome": "bun scripts/import-blender-dome.mjs"
 	},

--- a/libs/maia-game/scripts/build-terrain-height-worker.mjs
+++ b/libs/maia-game/scripts/build-terrain-height-worker.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+/**
+ * Bundle terrain-height-worker.mjs into a single ESM file (imports terrain.js graph).
+ * Served at /game-workers/terrain-height-worker.mjs — raw source cannot be used (relative imports 404).
+ */
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const gameRoot = join(__dirname, '..')
+const outDir = join(gameRoot, 'dist/game-workers')
+mkdirSync(outDir, { recursive: true })
+
+const entry = join(gameRoot, 'src/terrain-height-worker.mjs')
+
+const result = await Bun.build({
+	entrypoints: [entry],
+	outdir: outDir,
+	naming: '[name].[ext]',
+	target: 'browser',
+	format: 'esm',
+	minify: process.env.NODE_ENV === 'production',
+	sourcemap: false,
+})
+
+if (!result.success) {
+	console.error(result.logs)
+	process.exit(1)
+}

--- a/libs/maia-game/src/terrain-height-worker.mjs
+++ b/libs/maia-game/src/terrain-height-worker.mjs
@@ -1,7 +1,6 @@
 /**
  * Module worker: batch height samples for terrain (same math as main thread).
- * Instantiate with `new Worker(new URL('./terrain-height-worker.mjs', import.meta.url), { type: 'module' })`.
- * Falls back to main-thread loops when workers are unavailable or bundling omits this file.
+ * Production/dev load the bundled script at `/game-workers/terrain-height-worker.js` (see terrain-height-workers.js).
  */
 import { terrainHeightAtPlaneXY } from './terrain.js'
 

--- a/libs/maia-game/src/terrain-height-workers.js
+++ b/libs/maia-game/src/terrain-height-workers.js
@@ -6,13 +6,22 @@
  * @param {number} requestedCount
  * @returns {{ workers: Worker[], dispose: () => void }}
  */
+/** Bundled worker is served at /game-workers/terrain-height-worker.js (dev + prod). Relative import.meta.url breaks after SPA bundling (404 → HTML). */
+function terrainHeightWorkerScriptUrl() {
+	if (typeof window !== 'undefined' && window.location?.href) {
+		return new URL('/game-workers/terrain-height-worker.js', window.location.href).href
+	}
+	return new URL('./terrain-height-worker.mjs', import.meta.url).href
+}
+
 export function createTerrainHeightWorkerPool(requestedCount) {
 	const workers = []
 	const n = Math.max(1, Math.min(4, requestedCount | 0))
+	const workerUrl = terrainHeightWorkerScriptUrl()
 	for (let i = 0; i < n; i++) {
 		try {
 			workers.push(
-				new Worker(new URL('./terrain-height-worker.mjs', import.meta.url), {
+				new Worker(workerUrl, {
 					type: 'module',
 				}),
 			)

--- a/libs/maia-loader/src/index.js
+++ b/libs/maia-loader/src/index.js
@@ -21,7 +21,7 @@ export {
 	updateSyncState,
 	waitForStoreReady,
 } from '@MaiaOS/db'
-// Re-export DataEngine and MaiaScriptEvaluator for server/agent (moai)
+// Re-export DataEngine and MaiaScriptEvaluator for server/agent (sync)
 export { DataEngine, MaiaScriptEvaluator } from '@MaiaOS/engines'
 export { getAllFactories } from '@MaiaOS/factories'
 // Re-export auth functions for convenience

--- a/libs/maia-logs/src/index.js
+++ b/libs/maia-logs/src/index.js
@@ -11,6 +11,7 @@ export {
 	createPerfTracer,
 	isStorageOpfsPerfEnabled,
 	logStorageOpfsStep,
+	perfAppVibes,
 	perfDbUpload,
 	perfEnginesChat,
 	perfEnginesPipeline,

--- a/libs/maia-logs/src/log-mode.js
+++ b/libs/maia-logs/src/log-mode.js
@@ -3,7 +3,7 @@
  *
  * Tokens (comma / semicolon / whitespace separated):
  * - **`perf.all`** — all PERF channels
- * - **`perf.scope.subscope`** — e.g. `perf.engines.pipeline`, `perf.storage.opfs`
+ * - **`perf.scope.subscope`** — e.g. `perf.engines.pipeline`, `perf.app.vibes`, `perf.storage.opfs`
  * - **`scope:subscope`** — granular PERF (e.g. `engines:pipeline`)
  * - **`debug.all`** — all DEBUG channels (`engines:loadBinary`, `app:cobinary`, …)
  * - **`debug.scope.name`** — e.g. `debug.engines.loadBinary`, `debug.app.cobinary`
@@ -22,7 +22,14 @@ const PERF_DOT = /^perf\.([^.]+)\.(.+)$/i
 /** `debug.scope.name` → `scope:name` */
 const DEBUG_DOT = /^debug\.([^.]+)\.(.+)$/i
 
-const PERF_ALL_KEYS = ['engines:pipeline', 'engines:chat', 'db:upload', 'storage:opfs', 'game:init']
+const PERF_ALL_KEYS = [
+	'engines:pipeline',
+	'engines:chat',
+	'db:upload',
+	'storage:opfs',
+	'game:init',
+	'app:vibes',
+]
 
 const DEBUG_ALL_KEYS = ['engines:loadbinary', 'app:cobinary', 'engines:runtime', 'db:storagehook']
 

--- a/libs/maia-logs/src/perf.js
+++ b/libs/maia-logs/src/perf.js
@@ -83,6 +83,7 @@ export const perfEnginesPipeline = createPerfTracer('engines', 'pipeline')
 export const perfEnginesChat = createPerfTracer('engines', 'chat')
 export const perfDbUpload = createPerfTracer('db', 'upload')
 export const perfGameInit = createPerfTracer('game', 'init')
+export const perfAppVibes = createPerfTracer('app', 'vibes')
 
 /**
  * @returns {boolean}

--- a/libs/maia-peer/src/coID.js
+++ b/libs/maia-peer/src/coID.js
@@ -138,6 +138,25 @@ export async function loadAccount(options) {
 
 	const INITIAL_LOAD_TIMEOUT = 3000
 
+	/** Avoid cojson "Error withLoadedAccount" log when storage has no account row (fresh DB / reseed). */
+	async function accountExistsInStorage(storage, id) {
+		const getCoValue = storage?.dbClient?.getCoValue
+		if (typeof getCoValue !== 'function' || !id?.startsWith('co_')) return null
+		try {
+			const row = await getCoValue.call(storage.dbClient, id)
+			return row != null
+		} catch {
+			return null
+		}
+	}
+
+	const existsInStorage = await accountExistsInStorage(finalStorage, accountID)
+	if (existsInStorage === false) {
+		const e = new Error('Account not found in storage (first-time setup - will be created)')
+		e.isAccountNotFound = true
+		throw e
+	}
+
 	// Peers at load time may be empty if WS connects later; setupSyncPeers registerPeersIfMissing + addPeer when node exists avoids duplicate PeerState (see sync-peers.js).
 	const loadPromise = LocalNode.withLoadedAccount({
 		crypto,

--- a/libs/maia-storage/src/adapters/postgres.js
+++ b/libs/maia-storage/src/adapters/postgres.js
@@ -15,14 +15,24 @@ import { emptyKnownState, logger } from 'cojson'
 import { StorageApiAsync } from 'cojson/dist/storage/storageAsync.js'
 import { DeletedCoValueDeletionStatus } from 'cojson/dist/storage/types.js'
 import pg from 'pg'
+import { normalizePostgresConnectionString } from '../normalizePostgresUrl.js'
 import { runMigrations } from '../schema/postgres.js'
 
 const opsStor = createOpsLogger('STORAGE')
 
-function wrapClient(client) {
+/**
+ * Serialize queries on a single pg.Client. pg@9 deprecates overlapping client.query() calls.
+ */
+function wrapSerializingClient(client) {
+	let tail = Promise.resolve()
+	const enqueue = (fn) => {
+		const p = tail.then(fn)
+		tail = p.catch(() => {})
+		return p
+	}
 	return {
-		query: (sql, params) => client.query(sql, params),
-		exec: (sql) => client.query(sql),
+		query: (sql, params) => enqueue(() => client.query(sql, params)),
+		exec: (sql) => enqueue(() => client.query(sql)),
 	}
 }
 
@@ -374,14 +384,15 @@ export async function createPostgresAdapter(connectionString, blobStore) {
 		)
 	}
 
-	const client = new pg.Client({ connectionString })
+	const normalized = normalizePostgresConnectionString(connectionString)
+	const client = new pg.Client({ connectionString: normalized })
 	await client.connect()
 
 	if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
 		opsStor.log('Postgres connected, running migrations...')
 	}
 
-	const db = wrapClient(client)
+	const db = wrapSerializingClient(client)
 	await runMigrations(db)
 
 	return new PostgresClient(client, blobStore)

--- a/libs/maia-storage/src/clearStorageForReseed.js
+++ b/libs/maia-storage/src/clearStorageForReseed.js
@@ -1,3 +1,5 @@
+import { normalizePostgresConnectionString } from './normalizePostgresUrl.js'
+
 /**
  * Clear DB and binary blob storage for reseed (PEER_SYNC_SEED=true).
  * Ensures a complete reset before loadOrCreateAgentAccount + seed.
@@ -24,7 +26,9 @@ export async function clearStorageForReseed(options = {}) {
 			throw new Error('[clearStorageForReseed] PEER_SYNC_STORAGE=postgres requires PEER_SYNC_DB_URL')
 		}
 		const pg = await import('pg')
-		const client = new pg.default.Client({ connectionString: databaseUrl })
+		const client = new pg.default.Client({
+			connectionString: normalizePostgresConnectionString(databaseUrl),
+		})
 		await client.connect()
 		try {
 			await client.query(

--- a/libs/maia-storage/src/normalizePostgresUrl.js
+++ b/libs/maia-storage/src/normalizePostgresUrl.js
@@ -1,0 +1,20 @@
+/**
+ * Normalize PEER_SYNC_DB_URL so pg / pg-connection-string do not emit SSL mode deprecation warnings.
+ * Maps sslmode=require|prefer|verify-ca to verify-full (explicit current behavior per libpq docs).
+ *
+ * @param {string} connectionString
+ * @returns {string}
+ */
+export function normalizePostgresConnectionString(connectionString) {
+	if (!connectionString || typeof connectionString !== 'string') return connectionString
+	try {
+		const u = new URL(connectionString)
+		const mode = u.searchParams.get('sslmode')
+		if (mode === 'require' || mode === 'prefer' || mode === 'verify-ca') {
+			u.searchParams.set('sslmode', 'verify-full')
+		}
+		return u.toString()
+	} catch {
+		return connectionString
+	}
+}

--- a/libs/maia-vibes/src/seeding.js
+++ b/libs/maia-vibes/src/seeding.js
@@ -1,5 +1,5 @@
 /**
- * Vibes Seeding API - Cycle-free entry for moai genesis
+ * Vibes Seeding API - Cycle-free entry for sync genesis
  *
  * No dependency on @MaiaOS/loader - safe for static import in bundled sync-server.mjs.
  * Used by loader for getAllVibeRegistries, buildSeedConfig, filterVibesForSeeding.

--- a/scripts/fly-next-setup.md
+++ b/scripts/fly-next-setup.md
@@ -5,14 +5,14 @@ Setup guide for **sync.next.maia.city** (sync) and **next.maia.city** (app) with
 ## 1. Create Fly Apps
 
 ```bash
-# Create sync app (replaces moai-next-maia-city)
+# Create sync app (Fly app name may still be moai-next-maia-city; service lives in services/sync)
 flyctl apps create sync-next-maia-city --org maia-city
 
 # App already exists
 flyctl apps create next-maia-city --org maia-city  # skip if exists
 ```
 
-**Note:** No volume needed for sync when using Neon Postgres. If you were using PGlite before, you can destroy the old moai app after migration.
+**Note:** No volume needed for sync when using Neon Postgres. If you were using PGlite before, you can destroy the old Fly app after migration.
 
 ## 2. Neon PostgreSQL Setup
 

--- a/services/app/README.md
+++ b/services/app/README.md
@@ -94,7 +94,7 @@ Production builds run `distros:build` then `bun build.js`.
 
 ## Port
 
-- **4200** (maia static server). Moai at **4201** (sync/API) — client connects directly via CORS.
+- **4200** (app static server). **Sync** at **4201** (WebSocket + API) — client connects directly via CORS.
 
 ## Tauri desktop (macOS)
 

--- a/services/app/build.js
+++ b/services/app/build.js
@@ -42,6 +42,25 @@ if (!existsSync(clientPath) || !existsSync(vibesPath)) {
 	process.exit(1)
 }
 
+const repoRoot = join(serviceDir, '../..')
+const terrainWorkerBuild = spawnSync('bun', ['run', 'build:terrain-worker'], {
+	cwd: join(repoRoot, 'libs/maia-game'),
+	stdio: 'inherit',
+	env: { ...process.env, NODE_ENV: 'production' },
+})
+if (terrainWorkerBuild.status !== 0) {
+	console.error('libs/maia-game build:terrain-worker failed')
+	process.exit(1)
+}
+const terrainWorkerSrc = join(repoRoot, 'libs/maia-game/dist/game-workers/terrain-height-worker.js')
+if (!existsSync(terrainWorkerSrc)) {
+	console.error('terrain-height-worker.js missing after maia-game build')
+	process.exit(1)
+}
+const gameWorkersOut = join(distDir, 'game-workers')
+mkdirSync(gameWorkersOut, { recursive: true })
+cpSync(terrainWorkerSrc, join(gameWorkersOut, 'terrain-height-worker.js'))
+
 // Bun doesn't inject import.meta.env like Vite - must define at build time for production
 // VITE_AVEN_TEST_MODE: NEVER add to production - test mode is localhost-only, in-memory
 const envDefine = {
@@ -110,7 +129,6 @@ await Bun.write(join(distDir, 'style.css'), bundledCss)
 // brand/ already in dist via sync-assets above
 
 // Copy RunAnywhere WASM from distros output (vendored during distros:build)
-const repoRoot = join(serviceDir, '../..')
 const distrosWasmDir = join(repoRoot, 'libs/maia-distros/output/runanywhere-wasm')
 const wasmOutDir = join(distDir, 'runanywhere-wasm')
 if (existsSync(distrosWasmDir)) {
@@ -146,6 +164,7 @@ const required = [
 		distHas('runanywhere-wasm/racommons-llamacpp-webgpu.js'),
 	],
 	['game-assets/geodesic-dome.glb', distHas('game-assets/geodesic-dome.glb')],
+	['game-workers/terrain-height-worker.js', distHas('game-workers/terrain-height-worker.js')],
 ]
 const missing = required.filter(([, ok]) => !ok).map(([p]) => p)
 if (missing.length > 0) {

--- a/services/app/dashboard.js
+++ b/services/app/dashboard.js
@@ -4,6 +4,7 @@
  */
 
 import { getAllVibeRegistries, resolveAccountCoIdsToProfiles } from '@MaiaOS/loader'
+import { createPerfTracer } from '@MaiaOS/logs'
 import { findSessionChatIntentActorId, PERSISTENT_CHAT_VIBE_KEY } from './maia-ai-global.js'
 import {
 	escapeHtml,
@@ -362,68 +363,81 @@ export async function renderVibeViewer(
 	_navigateToScreen,
 	currentSpark = '°Maia',
 ) {
-	const accountId = maia?.id?.maiaId?.id || ''
-	let accountDisplayName = truncate(accountId, 12)
-	let accountAvatarHtml = ''
-	if (accountId?.startsWith('co_z') && maia?.do) {
-		try {
-			const profiles = await resolveAccountCoIdsToProfiles(maia, [accountId])
-			const accountProfile = profiles.get(accountId) ?? null
-			accountDisplayName = accountProfile?.name ?? accountDisplayName
-			accountAvatarHtml = getProfileAvatarHtml(accountProfile?.image, {
-				size: 44,
-				className: 'navbar-avatar',
-				syncState,
-			})
-		} catch (_e) {}
-	}
-	if (accountId && !accountAvatarHtml) {
-		accountAvatarHtml = getProfileAvatarHtml(null, { size: 44, className: 'navbar-avatar' })
-	}
-	// Dvibes (special screens): hardcoded names. Dynamic vibes: resolved from registry manifest.
-	const dvibeNameMap = { db: 'MaiaDB' }
-	let vibeLabel = 'Vibe'
-	if (currentVibe) {
-		if (dvibeNameMap[currentVibe]) {
-			vibeLabel = dvibeNameMap[currentVibe]
-		} else {
-			const registries = await getAllVibeRegistries()
-			const reg = registries.find((r) => r?.vibe?.$id === `°Maia/vibe/${currentVibe}`)
-			vibeLabel = reg?.vibe?.name ?? `${currentVibe.charAt(0).toUpperCase() + currentVibe.slice(1)}`
-		}
-	}
-
-	// Park persistent Chat intent off-screen so destroyActorsForContainer does not tear down the tree
-	if (maia?.runtime) {
-		const intentId = findSessionChatIntentActorId(maia)
-		if (intentId) {
-			let host = document.getElementById('maia-session-chat-host')
-			if (!host) {
-				host = document.createElement('div')
-				host.id = 'maia-session-chat-host'
-				host.setAttribute('aria-hidden', 'true')
-				host.style.cssText =
-					'position:fixed;width:0;height:0;overflow:hidden;pointer-events:none;visibility:hidden'
-				document.body.appendChild(host)
-			}
+	const perf = createPerfTracer('app', 'vibes')
+	perf.start(`renderVibeViewer:${currentVibe}`)
+	try {
+		const accountId = maia?.id?.maiaId?.id || ''
+		let accountDisplayName = truncate(accountId, 12)
+		let accountAvatarHtml = ''
+		if (accountId?.startsWith('co_z') && maia?.do) {
 			try {
-				await maia.getEngines().actorEngine.reuseActor(intentId, host, PERSISTENT_CHAT_VIBE_KEY)
+				await perf.measure('resolveAccountProfile', async () => {
+					const profiles = await resolveAccountCoIdsToProfiles(maia, [accountId])
+					const accountProfile = profiles.get(accountId) ?? null
+					accountDisplayName = accountProfile?.name ?? accountDisplayName
+					accountAvatarHtml = getProfileAvatarHtml(accountProfile?.image, {
+						size: 44,
+						className: 'navbar-avatar',
+						syncState,
+					})
+				})
 			} catch (_e) {}
 		}
-	}
-
-	// Clear any existing vibe containers before rendering new one
-	// This ensures we don't have multiple aven containers stacked
-	const app = document.getElementById('app')
-	if (app) {
-		const existingContainers = app.querySelectorAll('.vibe-container')
-		for (const container of existingContainers) {
-			if (maia?.runtime) maia.runtime.destroyActorsForContainer(container)
-			container.remove()
+		if (accountId && !accountAvatarHtml) {
+			accountAvatarHtml = getProfileAvatarHtml(null, { size: 44, className: 'navbar-avatar' })
 		}
-	}
+		perf.step('profile+avatar')
+		// Dvibes (special screens): hardcoded names. Dynamic vibes: resolved from registry manifest.
+		const dvibeNameMap = { db: 'MaiaDB' }
+		let vibeLabel = 'Vibe'
+		if (currentVibe) {
+			if (dvibeNameMap[currentVibe]) {
+				vibeLabel = dvibeNameMap[currentVibe]
+			} else {
+				await perf.measure('getAllVibeRegistries+vibeLabel', async () => {
+					const registries = await getAllVibeRegistries()
+					const reg = registries.find((r) => r?.vibe?.$id === `°Maia/vibe/${currentVibe}`)
+					vibeLabel = reg?.vibe?.name ?? `${currentVibe.charAt(0).toUpperCase() + currentVibe.slice(1)}`
+				})
+			}
+		}
+		perf.step('vibeTitle')
 
-	app.innerHTML = `
+		// Park persistent Chat intent off-screen so destroyActorsForContainer does not tear down the tree
+		if (maia?.runtime) {
+			await perf.measure('chatIntentReuse', async () => {
+				const intentId = findSessionChatIntentActorId(maia)
+				if (intentId) {
+					let host = document.getElementById('maia-session-chat-host')
+					if (!host) {
+						host = document.createElement('div')
+						host.id = 'maia-session-chat-host'
+						host.setAttribute('aria-hidden', 'true')
+						host.style.cssText =
+							'position:fixed;width:0;height:0;overflow:hidden;pointer-events:none;visibility:hidden'
+						document.body.appendChild(host)
+					}
+					try {
+						await maia.getEngines().actorEngine.reuseActor(intentId, host, PERSISTENT_CHAT_VIBE_KEY)
+					} catch (_e) {}
+				}
+			})
+		}
+		perf.step('afterChatHost')
+
+		// Clear any existing vibe containers before rendering new one
+		// This ensures we don't have multiple aven containers stacked
+		const app = document.getElementById('app')
+		if (app) {
+			const existingContainers = app.querySelectorAll('.vibe-container')
+			for (const container of existingContainers) {
+				if (maia?.runtime) maia.runtime.destroyActorsForContainer(container)
+				container.remove()
+			}
+		}
+		perf.step('destroyOldContainers')
+
+		app.innerHTML = `
 		<div class="db-container">
 			<div class="navbar-section">
 			<header class="db-header whitish-card">
@@ -482,126 +496,142 @@ export async function renderVibeViewer(
 			</div>
 		</div>
 	`
+		perf.step('shellDOM')
 
-	// Add sidebar toggle handlers for maiadb vibe
-	setTimeout(() => {
-		const vibeContainer = document.querySelector('.vibe-container')
-		if (vibeContainer?.shadowRoot) {
-			const navAside = vibeContainer.shadowRoot.querySelector('.nav-aside')
-			const detailAside = vibeContainer.shadowRoot.querySelector('.detail-aside')
+		// Add sidebar toggle handlers for maiadb vibe
+		setTimeout(() => {
+			const vibeContainer = document.querySelector('.vibe-container')
+			if (vibeContainer?.shadowRoot) {
+				const navAside = vibeContainer.shadowRoot.querySelector('.nav-aside')
+				const detailAside = vibeContainer.shadowRoot.querySelector('.detail-aside')
 
-			// Start collapsed by default, no transitions
-			if (navAside) {
-				navAside.classList.add('collapsed')
-			}
-			if (detailAside) {
-				detailAside.classList.add('collapsed')
-			}
+				// Start collapsed by default, no transitions
+				if (navAside) {
+					navAside.classList.add('collapsed')
+				}
+				if (detailAside) {
+					detailAside.classList.add('collapsed')
+				}
 
-			// Add toggle handlers
-			const navToggle = vibeContainer.shadowRoot.querySelector('.nav-toggle')
-			const detailToggle = vibeContainer.shadowRoot.querySelector('.detail-toggle')
+				// Add toggle handlers
+				const navToggle = vibeContainer.shadowRoot.querySelector('.nav-toggle')
+				const detailToggle = vibeContainer.shadowRoot.querySelector('.detail-toggle')
 
-			if (navToggle) {
-				navToggle.addEventListener('click', () => {
-					if (navAside) {
-						// Enable transitions when user explicitly toggles
-						navAside.classList.add('sidebar-ready')
-						navAside.classList.toggle('collapsed')
-					}
-				})
-			}
+				if (navToggle) {
+					navToggle.addEventListener('click', () => {
+						if (navAside) {
+							// Enable transitions when user explicitly toggles
+							navAside.classList.add('sidebar-ready')
+							navAside.classList.toggle('collapsed')
+						}
+					})
+				}
 
-			if (detailToggle) {
-				detailToggle.addEventListener('click', () => {
-					if (detailAside) {
-						// Enable transitions when user explicitly toggles
-						detailAside.classList.add('sidebar-ready')
-						detailAside.classList.toggle('collapsed')
-					}
-				})
-			}
-		}
-	}, 100)
-
-	// Load aven asynchronously after DOM is updated
-	requestAnimationFrame(async () => {
-		try {
-			await new Promise((resolve) => setTimeout(resolve, 10))
-
-			// Ensure only one aven container exists (cleanup any duplicates)
-			const allContainers = document.querySelectorAll('.vibe-container')
-			if (allContainers.length > 1) {
-				const targetContainer = document.getElementById(`vibe-container-${currentVibe}`)
-				for (const container of allContainers) {
-					if (container !== targetContainer) {
-						container.remove()
-					}
+				if (detailToggle) {
+					detailToggle.addEventListener('click', () => {
+						if (detailAside) {
+							// Enable transitions when user explicitly toggles
+							detailAside.classList.add('sidebar-ready')
+							detailAside.classList.toggle('collapsed')
+						}
+					})
 				}
 			}
+		}, 100)
 
-			const container = document.getElementById(`vibe-container-${currentVibe}`)
-			if (!container) {
-				return
-			}
-			if (!maia) {
-				return
-			}
+		// Await rAF + loadVibeFromAccount so loadVibe/renderApp timing includes real mount (was fire-and-forget).
+		await new Promise((resolve, reject) => {
+			requestAnimationFrame(() => {
+				void (async () => {
+					try {
+						await new Promise((r) => setTimeout(r, 10))
+						perf.step('rAF+10ms')
 
-			// Clear container before loading new vibe (remove any existing content)
-			container.innerHTML = ''
-
-			if (currentVibe === 'chat') {
-				const intentId = findSessionChatIntentActorId(maia)
-				if (intentId) {
-					await maia.getEngines().actorEngine.reuseActor(intentId, container, PERSISTENT_CHAT_VIBE_KEY)
-				} else {
-					await maia.loadVibeFromAccount(
-						'chat',
-						container,
-						currentSpark || '°Maia',
-						PERSISTENT_CHAT_VIBE_KEY,
-					)
-				}
-			} else {
-				await maia.loadVibeFromAccount(currentVibe, container, currentSpark || '°Maia')
-			}
-
-			// Add sidebar toggle handlers for maiadb vibe (after vibe loads)
-			setTimeout(() => {
-				const vibeContainerEl = document.getElementById(`vibe-container-${currentVibe}`)
-				if (vibeContainerEl) {
-					const shadowRoot = vibeContainerEl.shadowRoot || vibeContainerEl
-					const navToggle = shadowRoot.querySelector('.nav-toggle')
-					const detailToggle = shadowRoot.querySelector('.detail-toggle')
-
-					if (navToggle) {
-						navToggle.addEventListener('click', () => {
-							const navAside = navToggle.closest('.nav-aside')
-							if (navAside) {
-								navAside.classList.toggle('collapsed')
+						const allContainers = document.querySelectorAll('.vibe-container')
+						if (allContainers.length > 1) {
+							const targetContainer = document.getElementById(`vibe-container-${currentVibe}`)
+							for (const container of allContainers) {
+								if (container !== targetContainer) {
+									container.remove()
+								}
 							}
-						})
-					}
+						}
 
-					if (detailToggle) {
-						detailToggle.addEventListener('click', () => {
-							const detailAside = detailToggle.closest('.detail-aside')
-							if (detailAside) {
-								detailAside.classList.toggle('collapsed')
+						const container = document.getElementById(`vibe-container-${currentVibe}`)
+						if (!container || !maia) {
+							resolve()
+							return
+						}
+
+						container.innerHTML = ''
+						perf.step('beforeLoadVibeFromAccount')
+
+						if (currentVibe === 'chat') {
+							const intentId = findSessionChatIntentActorId(maia)
+							if (intentId) {
+								await perf.measure('loadVibeFromAccount(chat reuse)', async () =>
+									maia.getEngines().actorEngine.reuseActor(intentId, container, PERSISTENT_CHAT_VIBE_KEY),
+								)
+							} else {
+								await perf.measure('loadVibeFromAccount(chat)', async () =>
+									maia.loadVibeFromAccount(
+										'chat',
+										container,
+										currentSpark || '°Maia',
+										PERSISTENT_CHAT_VIBE_KEY,
+									),
+								)
 							}
-						})
-					}
-				}
-			}, 500)
+						} else {
+							await perf.measure('loadVibeFromAccount', async () =>
+								maia.loadVibeFromAccount(currentVibe, container, currentSpark || '°Maia'),
+							)
+						}
+						perf.step('afterLoadVibeFromAccount')
 
-			// Store container reference for cleanup on unload
-			window.currentVibeContainer = container
-		} catch (error) {
-			const container = document.getElementById(`vibe-container-${currentVibe}`)
-			if (container) {
-				container.innerHTML = `<div class="empty-state p-8 text-center text-rose-500 font-medium bg-rose-50/50 rounded-2xl border border-rose-100">Error loading aven: ${escapeHtml(error.message)}</div>`
-			}
-		}
-	})
+						setTimeout(() => {
+							const vibeContainerEl = document.getElementById(`vibe-container-${currentVibe}`)
+							if (vibeContainerEl) {
+								const shadowRoot = vibeContainerEl.shadowRoot || vibeContainerEl
+								const navToggle = shadowRoot.querySelector('.nav-toggle')
+								const detailToggle = shadowRoot.querySelector('.detail-toggle')
+
+								if (navToggle) {
+									navToggle.addEventListener('click', () => {
+										const navAside = navToggle.closest('.nav-aside')
+										if (navAside) {
+											navAside.classList.toggle('collapsed')
+										}
+									})
+								}
+
+								if (detailToggle) {
+									detailToggle.addEventListener('click', () => {
+										const detailAside = detailToggle.closest('.detail-aside')
+										if (detailAside) {
+											detailAside.classList.toggle('collapsed')
+										}
+									})
+								}
+							}
+						}, 500)
+
+						window.currentVibeContainer = container
+						resolve()
+					} catch (error) {
+						const container = document.getElementById(`vibe-container-${currentVibe}`)
+						if (container) {
+							container.innerHTML = `<div class="empty-state p-8 text-center text-rose-500 font-medium bg-rose-50/50 rounded-2xl border border-rose-100">Error loading aven: ${escapeHtml(error.message)}</div>`
+						}
+						reject(error)
+					}
+				})()
+			})
+		})
+
+		perf.end('renderVibeViewer')
+	} catch (e) {
+		perf.end('renderVibeViewer(error)')
+		throw e
+	}
 }

--- a/services/app/db-view.js
+++ b/services/app/db-view.js
@@ -811,7 +811,7 @@ export async function renderApp(
 						schemaId.includes('factories-registry') ||
 						schemaId.includes('indexes-registry')
 					const emptyHint = isRegistryEmpty
-						? '<p class="mt-3 text-sm text-amber-600 max-w-md mx-auto">Vibes/schemas come from the sync server. Run <code class="bg-amber-100 px-1 rounded">bun dev</code> (moai on :4201), sign in, and check console for <code class="bg-amber-100 px-1 rounded">linkAccountToSyncRegistry</code>.</p>'
+						? '<p class="mt-3 text-sm text-amber-600 max-w-md mx-auto">Vibes/schemas come from the sync server. Run <code class="bg-amber-100 px-1 rounded">bun dev</code> (sync on :4201), sign in, and check console for <code class="bg-amber-100 px-1 rounded">linkAccountToSyncRegistry</code>.</p>'
 						: ''
 					tableContent = `<div class="p-12 italic text-center rounded-2xl border border-dashed empty-state text-slate-400 bg-slate-50/30 border-slate-200">No properties available${emptyHint}</div>`
 				} else {

--- a/services/app/dev-server.js
+++ b/services/app/dev-server.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { spawnSync } from 'node:child_process'
 import { existsSync, statSync } from 'node:fs'
 /**
  * Maia dev server: static /brand/* + /runanywhere-wasm/* + Bun HTML bundling with HMR.
@@ -30,6 +31,23 @@ function withCrossOriginIsolation(response) {
 	})
 }
 
+const terrainWorkerBundled = join(
+	repoRoot,
+	'libs/maia-game/dist/game-workers/terrain-height-worker.js',
+)
+if (!existsSync(terrainWorkerBundled)) {
+	console.log('[dev-server] Building terrain-height-worker bundle…')
+	const r = spawnSync('bun', ['run', 'build:terrain-worker'], {
+		cwd: join(repoRoot, 'libs/maia-game'),
+		stdio: 'inherit',
+	})
+	if (r.status !== 0) {
+		console.error(
+			'[dev-server] terrain-height-worker build failed — terrain may fall back to main thread',
+		)
+	}
+}
+
 const MIME = {
 	'.css': 'text/css',
 	'.svg': 'image/svg+xml',
@@ -41,6 +59,7 @@ const MIME = {
 	'.json': 'application/json',
 	'.webmanifest': 'application/manifest+json',
 	'.js': 'application/javascript',
+	'.mjs': 'application/javascript',
 	'.wasm': 'application/wasm',
 	'.glb': 'model/gltf-binary',
 }
@@ -134,6 +153,18 @@ Bun.serve({
 		}
 
 		// Serve RunAnywhere WASM (llamacpp + sherpa) with correct MIME types
+		if (pathname === '/game-workers/terrain-height-worker.js') {
+			if (existsSync(terrainWorkerBundled) && statSync(terrainWorkerBundled).isFile()) {
+				return new Response(Bun.file(terrainWorkerBundled), {
+					headers: { 'Content-Type': 'application/javascript', ...COOP_COEP },
+				})
+			}
+			return new Response(
+				'terrain-height-worker not built — run: cd libs/maia-game && bun run build:terrain-worker',
+				{ status: 503, headers: COOP_COEP },
+			)
+		}
+
 		if (pathname.startsWith('/runanywhere-wasm/')) {
 			const filePath = resolveRunAnywhereWasmPath(pathname)
 			if (filePath && existsSync(filePath) && statSync(filePath).isFile()) {

--- a/services/app/dev-server.js
+++ b/services/app/dev-server.js
@@ -211,5 +211,5 @@ Bun.serve({
 })
 
 console.log(
-	'Local: http://localhost:4200 (brand at /brand; runanywhere-wasm at /runanywhere-wasm; moai at :4201)',
+	'Local: http://localhost:4200 (brand at /brand; runanywhere-wasm at /runanywhere-wasm; sync at :4201)',
 )

--- a/services/app/main.js
+++ b/services/app/main.js
@@ -19,7 +19,7 @@ import {
 	subscribeSyncState,
 	updateSyncState,
 } from '@MaiaOS/loader'
-import { applyLogModeFromEnv } from '@MaiaOS/logs'
+import { applyLogModeFromEnv, createPerfTracer } from '@MaiaOS/logs'
 import { getSyncHttpBaseUrl } from '@MaiaOS/peer'
 import { renderApp } from './db-view.js'
 import { renderLandingPage } from './landing.js'
@@ -1281,12 +1281,15 @@ async function loadVibe(vibeKey) {
 		return
 	}
 
+	const perf = createPerfTracer('app', 'vibes')
 	try {
+		perf.start(`loadVibe(${vibeKey === null ? 'close' : vibeKey})`)
 		if (typeof window !== 'undefined' && window._maiaDebugFreeze) {
 		}
 		if (vibeKey === null) {
 			if (currentVibe && maia?.runtime) {
 				maia.runtime.destroyActorsForVibe(currentVibe)
+				perf.step('destroyActorsForVibe(close)')
 			}
 
 			_currentVibeContainer = null
@@ -1294,9 +1297,11 @@ async function loadVibe(vibeKey) {
 
 			currentVibe = null
 			navigateToScreen('dashboard')
+			perf.step('navigateToScreen(dashboard)')
 		} else {
 			if (currentVibe && currentVibe !== vibeKey && maia?.runtime) {
 				maia.runtime.destroyActorsForVibe(currentVibe)
+				perf.step('destroyActorsForVibe(switch)')
 			}
 
 			if (currentContextCoValueId !== null) {
@@ -1305,12 +1310,15 @@ async function loadVibe(vibeKey) {
 			currentVibe = vibeKey
 			currentContextCoValueId = null
 			currentScreen = 'vibe-viewer'
+			perf.step('state→vibe-viewer')
 		}
 
-		await renderAppInternal()
+		await perf.measure('renderAppInternal', async () => renderAppInternal())
+		perf.end('loadVibe')
 		if (typeof window !== 'undefined' && window._maiaDebugFreeze) {
 		}
 	} catch (_error) {
+		perf.end('loadVibe(error)')
 		currentVibe = null
 		await renderAppInternal()
 	}

--- a/services/app/main.js
+++ b/services/app/main.js
@@ -52,6 +52,15 @@ function caughtErrName(error) {
 	return ''
 }
 
+/** Wait until after the next composited frame (double rAF) so PERF includes visible paint. */
+function waitUntilNextPaint() {
+	return new Promise((resolve) => {
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => resolve())
+		})
+	})
+}
+
 let maia
 let currentScreen = 'dashboard' // Current screen: 'dashboard' | 'maia-db' | 'the-game' | 'vibe-viewer' | …
 let currentView = 'account' // Current schema filter (default: 'account')
@@ -1296,8 +1305,13 @@ async function loadVibe(vibeKey) {
 			window.currentVibeContainer = null
 
 			currentVibe = null
-			navigateToScreen('dashboard')
-			perf.step('navigateToScreen(dashboard)')
+			// Match navigateToScreen('dashboard') state but do not call render here — that would race
+			// the awaited renderAppInternal below (second call returns early while isRendering).
+			currentScreen = 'dashboard'
+			currentContextCoValueId = null
+			currentSpark = null
+			navigationHistory = []
+			perf.step('state→dashboard')
 		} else {
 			if (currentVibe && currentVibe !== vibeKey && maia?.runtime) {
 				maia.runtime.destroyActorsForVibe(currentVibe)
@@ -1314,6 +1328,10 @@ async function loadVibe(vibeKey) {
 		}
 
 		await perf.measure('renderAppInternal', async () => renderAppInternal())
+		if (vibeKey === null) {
+			await waitUntilNextPaint()
+			perf.step('afterPaint(dashboard)')
+		}
 		perf.end('loadVibe')
 		if (typeof window !== 'undefined' && window._maiaDebugFreeze) {
 		}

--- a/services/sync/src/index.js
+++ b/services/sync/src/index.js
@@ -10,7 +10,7 @@
  *   PEER_SYNC_STORAGE=pglite | postgres (required - server never runs without persistent storage)
  *     - pglite: PEER_DB_PATH (default ./pg-lite.db)
  *     - postgres: PEER_SYNC_DB_URL (required)
- *   AVEN_MAIA_GUARDIAN: Human account co-id (co_z...). If set, add as admin of °Maia spark guardian. Retries until success (account may sync after client connects).
+ *   AVEN_MAIA_GUARDIAN: Human account co-id (co_z...). If set, add as admin of °Maia spark guardian; also seeds /sync/write so that account can sync without POST /register.
  *   PEER_SYNC_SEED: Default false. Set true to run genesis seed (bootstrap + schemas + vibes).
  *     - true: Fresh seed (first deploy or intentional reset). May overwrite existing scaffold.
  *     - false/unset: Skip seed, use persisted data. Never overwrite on restart.
@@ -265,6 +265,21 @@ async function seedAdminCapabilityForServerAccount(worker) {
 	await pushCapabilityToStream(worker, { sub: accountID, cmd: '/admin', pol: [], exp })
 }
 
+/**
+ * Ensure AVEN_MAIA_GUARDIAN has /sync/write and /llm/chat (same grants as POST /register for humans).
+ * Without this, the guardian’s browser session syncs but every write hits ValidationHook — they never called /register.
+ */
+async function seedCapabilitiesForGuardian(worker) {
+	if (!avenMaiaGuardian?.startsWith('co_z')) return
+	if (avenMaiaGuardian === accountID) return
+	const exp = Math.floor(Date.now() / 1000) + 10 * 365 * 24 * 3600
+	for (const cmd of ['/sync/write', '/llm/chat']) {
+		const has = await hasValidCapability(worker, avenMaiaGuardian, cmd)
+		if (has) continue
+		await pushCapabilityToStream(worker, { sub: avenMaiaGuardian, cmd, pol: [], exp })
+	}
+}
+
 /** Check if account has valid capability for cmd from spark.os.capabilities stream. /admin grants all. */
 async function hasValidCapability(worker, accountId, cmd) {
 	if (!accountId?.startsWith('co_z') || !cmd) return false
@@ -342,7 +357,7 @@ async function resolveAgentIdToAccountId(worker, agentId) {
 		}
 		const registriesId = getRegistriesId(worker.account)
 		const registriesContent = await loadCoMap(worker.peer, registriesId, { retries: 1 })
-		// Check registries.sparks (agent may be registered as spark, e.g. Moai)
+		// Check registries.sparks (agent may be registered as a spark)
 		const sparksId = registriesContent?.get?.('sparks')
 		if (sparksId?.startsWith('co_z')) {
 			const sparksRaw = await worker.peer.getRawRecord(sparksId)
@@ -1142,6 +1157,10 @@ opsSync.log('Listening on 0.0.0.0:%s', PORT)
 		// Seed /admin for AVEN_MAIA_ACCOUNT (grants all endpoints). Must run after scaffold exists (genesis or prior run).
 		await seedAdminCapabilityForServerAccount(agentWorker).catch((e) =>
 			opsSync.warn('seedAdminCapabilityForServerAccount:', e?.message),
+		)
+
+		await seedCapabilitiesForGuardian(agentWorker).catch((e) =>
+			opsSync.warn('seedCapabilitiesForGuardian:', e?.message),
 		)
 
 		// Self-register Maia aven in registries.avens for profile resolution (idempotent)

--- a/services/sync/src/index.js
+++ b/services/sync/src/index.js
@@ -1168,7 +1168,16 @@ opsSync.log('Listening on 0.0.0.0:%s', PORT)
 					if (ok) opsSync.log('Added guardian as admin of °Maia spark.')
 				})
 				.catch((e) => {
-					opsSync.warn('Guardian add deferred (will retry):', e?.message ?? e)
+					const msg = e?.message ?? String(e)
+					const waitingForSync =
+						msg.includes('Timeout waiting for CoValue') || msg.includes('not available')
+					if (waitingForSync) {
+						opsSync.log(
+							'Guardian admin pending: guardian account not in server storage yet (connect app once); retrying every 15s.',
+						)
+					} else {
+						opsSync.warn('Guardian add deferred (will retry):', msg)
+					}
 					const retryMs = 15000
 					const id = setInterval(async () => {
 						try {


### PR DESCRIPTION
## Summary
- **Postgres SSL:** `normalizePostgresConnectionString` maps `sslmode=require|prefer|verify-ca` to `verify-full` so pg-connection-string stops printing the v3 migration warning.
- **pg DeprecationWarning:** Serialize all `query`/`exec` on the single `pg.Client` so cojson storage never overlaps `client.query()` calls.
- **SchemaIndexManager:** Log “registries not set” once during bootstrap instead of dozens of lines.
- **`Error withLoadedAccount`:** If `storage.dbClient.getCoValue(accountID)` returns no row, skip `LocalNode.withLoadedAccount` and throw the same “not found” path `loadOrCreateAgentAccount` already handles (no cojson error dump).
- **Guardian:** Expected “guardian not in storage yet” uses an info log instead of warn.

## Test plan
- [ ] Deploy sync; confirm Fly logs no longer show SSL warning spam, pg deprecation, or cojson withLoadedAccount blob on fresh account create
- [ ] Open app as guardian once; confirm guardian admin eventually applies or retries quietly