### PR TITLE
[fix] Version-tag GH006, profile/vibes/guardian, sync terminology

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          # Otherwise GITHUB_TOKEN is stored for HTTPS; git push uses it and GH006 rejects protected `next`.
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
 
@@ -48,6 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          git remote set-url origin "git@github.com:${{ github.repository }}.git"
           git push origin next
           git push origin "v${{ steps.version.outputs.version }}"
           gh release create "v${{ steps.version.outputs.version }}" \


### PR DESCRIPTION
## Version-tag (CI)
- `persist-credentials: false` + explicit `git@github.com` remote so `git push` uses the SSH deploy key, not `GITHUB_TOKEN`, avoiding **GH006** on protected `next`.

## App / DB / sync (from branch)
- Self profile resolution before registries (avoids ~5s waits).
- `loadVibe(close)` perf: single render + paint wait.
- Guardian: seed `/sync/write` + `/llm/chat` when needed.
- Docs/dev copy: moai → sync where it names the service.