### PR TITLE
[fix] Passkey sign-in: wait for sync peer; remove OPFS storage gate

### DIFF
--- a/libs/maia-peer/src/coID.js
+++ b/libs/maia-peer/src/coID.js
@@ -138,24 +138,9 @@ export async function loadAccount(options) {
 
 	const INITIAL_LOAD_TIMEOUT = 3000
 
-	/** Avoid cojson "Error withLoadedAccount" log when storage has no account row (fresh DB / reseed). */
-	async function accountExistsInStorage(storage, id) {
-		const getCoValue = storage?.dbClient?.getCoValue
-		if (typeof getCoValue !== 'function' || !id?.startsWith('co_')) return null
-		try {
-			const row = await getCoValue.call(storage.dbClient, id)
-			return row != null
-		} catch {
-			return null
-		}
-	}
-
-	const existsInStorage = await accountExistsInStorage(finalStorage, accountID)
-	if (existsInStorage === false) {
-		const e = new Error('Account not found in storage (first-time setup - will be created)')
-		e.isAccountNotFound = true
-		throw e
-	}
+	// Do not require a local row before withLoadedAccount: a new browser has empty OPFS until sync
+	// hydrates. Callers must register WebSocket peers first — setupSyncPeers fills `peers` in addPeer
+	// asynchronously, so peers.length may be 0 if loadAccount runs too early (see signInWithPasskey).
 
 	// Peers at load time may be empty if WS connects later; setupSyncPeers registerPeersIfMissing + addPeer when node exists avoids duplicate PeerState (see sync-peers.js).
 	const loadPromise = LocalNode.withLoadedAccount({

--- a/libs/maia-self/src/self.js
+++ b/libs/maia-self/src/self.js
@@ -158,8 +158,17 @@ export async function signInWithPasskey({ salt = 'maia.city' } = {}) {
 	// Use loadAccount() abstraction from @MaiaOS/db instead of direct withLoadedAccount()
 	const accountLoadingPromise = (async () => {
 		try {
-			// Local-first: load account from storage immediately; WebSocket connects in parallel (setupSyncPeers).
-			// Use loadAccount() abstraction - goes through proper abstraction layer
+			// peers[] is filled in addPeer when the WebSocket connects — it is empty on the first tick.
+			// Wait until at least one peer is registered (or timeout) so loadAccount can hydrate from sync.
+			if (syncSetup?.wsPeer) {
+				if (typeof syncSetup.waitForPeer === 'function') {
+					await syncSetup.waitForPeer()
+				}
+				const deadline = Date.now() + 30000
+				while (syncSetup.peers.length === 0 && Date.now() < deadline) {
+					await new Promise((r) => setTimeout(r, 50))
+				}
+			}
 			const loadResult = await loadAccount({
 				accountID,
 				agentSecret,

--- a/services/app/main.js
+++ b/services/app/main.js
@@ -226,13 +226,15 @@ async function handleRoute() {
 		if (authState.signedIn && !maia) {
 			renderLoadingConnectingScreen()
 			let waitCount = 0
+			// First load on a new browser can pull a large account from sync; allow up to ~60s before giving up.
+			const maxTicks = 120
 			const checkMaia = setInterval(() => {
 				waitCount++
 				if (maia) {
 					clearInterval(checkMaia)
 					cleanupLoadingScreenSync()
 					renderAppInternal().catch((e) => showToast(`Failed to render app: ${e.message}`, 'error'))
-				} else if (waitCount > 20) {
+				} else if (waitCount > maxTicks) {
 					clearInterval(checkMaia)
 					cleanupLoadingScreenSync()
 					authState = { signedIn: false, accountID: null }
@@ -643,6 +645,8 @@ async function signIn() {
 
 		// Mark that user has successfully authenticated
 		markAccountExists()
+
+		setSignInLoading(false)
 
 		// Await account loading in background and boot MaiaOS when ready
 		loadingPromise


### PR DESCRIPTION
## Summary
- **coID:** Remove pre-check that blocked `withLoadedAccount` when OPFS had no account row (first-time / new browser).
- **self:** After `waitForPeer()`, poll until `syncSetup.peers` is populated (`addPeer` runs after WebSocket connects).
- **main:** Longer `/me` wait for first sync; clear sign-in loading after passkey.

## Testing
- Local: `bun dev`, passkey sign-in on fresh profile / cleared storage.