### PR TITLE
[feat] Maia universe stack, CI/deploy fixes, PEER_SYNC_MODE

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
       "name": "@MaiaOS/universe",
       "version": "26.4.21315-next",
       "dependencies": {
+        "@MaiaOS/db": "workspace:*",
         "@MaiaOS/peer": "workspace:*",
         "@MaiaOS/runtime": "workspace:*",
         "@noble/hashes": "2.2.0",

--- a/libs/maia-universe/package.json
+++ b/libs/maia-universe/package.json
@@ -21,6 +21,7 @@
 		"./config/derive-inbox.js": "./src/config/derive-inbox.js"
 	},
 	"dependencies": {
+		"@MaiaOS/db": "workspace:*",
 		"@MaiaOS/peer": "workspace:*",
 		"@MaiaOS/runtime": "workspace:*",
 		"@noble/hashes": "2.2.0",

--- a/services/app/Dockerfile
+++ b/services/app/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 # Copy monorepo
 COPY package.json bun.lock* ./
+COPY jsconfig.json ./
 COPY libs ./libs
 COPY services/app ./services/app
 COPY services/sync ./services/sync

--- a/services/sync/Dockerfile
+++ b/services/sync/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 # Copy monorepo
 COPY package.json bun.lock* ./
+COPY jsconfig.json ./
 COPY libs ./libs
 COPY services/app ./services/app
 COPY services/sync ./services/sync


### PR DESCRIPTION
## Summary

Brings the Maia universe / identity / seed / runtime work on `samuel/next` into `next`, plus fixes that unblock **Lint**, **Build**, and **Deploy Next** (app + sync).

## CI & build

- **Universe registry:** Generated files are gitignored; `bun run universe:registry` runs in CI and in app/sync Docker builds before `distros:build`. Vibe bucket output is sorted by nanoid for stable cross-OS output. Removed the old `git diff` registry check.
- **distros:build:** Uses `cd libs/maia-distros && bun run build` instead of `bun run --filter` (avoids **ENOENT** on Linux runners).
- **Bundles:** `unicode-segmenter` is declared where imported; `@noble/hashes` bumped to **2.2.0** on explicit dependents.
- **Universe → DB:** `@MaiaOS/db` added to `@MaiaOS/universe` for `profile-image` pipe imports.
- **Docker:** **`jsconfig.json` is copied** into the builder image so `Bun.build` path aliases (`@MaiaOS/db`, etc.) resolve during `distros:build` (fixes Fly image build failures).

## Product / platform

- **PEER_SYNC_MODE** replaces separate seed/migrate env flags (see `68d75f77`).
- Broader universe registry, validation, seed orchestration, runtime merges, and related features as in commit history on this branch.

## Verify

- [ ] `bun run check:ci` / CI green on the PR
- [ ] Deploy Next succeeds for app and sync after merge