### PR TITLE
[fix] Vendor pglite.wasm path for Bun/Docker (sync deploy)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,11 +14,11 @@
     },
     "libs/maia-brand": {
       "name": "@MaiaOS/brand",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
     },
     "libs/maia-db": {
       "name": "@MaiaOS/db",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/logs": "workspace:*",
         "@MaiaOS/peer": "workspace:*",
@@ -29,17 +29,18 @@
     },
     "libs/maia-distros": {
       "name": "@MaiaOS/maia-distros",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/runtime": "workspace:*",
         "@MaiaOS/universe": "workspace:*",
         "@MaiaOS/validation": "workspace:*",
+        "@electric-sql/pglite": "0.4.2",
       },
     },
     "libs/maia-game": {
       "name": "@MaiaOS/game",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/logs": "workspace:*",
         "three": "0.170.0",
@@ -47,11 +48,11 @@
     },
     "libs/maia-logs": {
       "name": "@MaiaOS/logs",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
     },
     "libs/maia-peer": {
       "name": "@MaiaOS/peer",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/logs": "workspace:*",
         "@MaiaOS/storage": "workspace:*",
@@ -61,7 +62,7 @@
     },
     "libs/maia-runtime": {
       "name": "@MaiaOS/runtime",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/logs": "workspace:*",
@@ -82,7 +83,7 @@
     },
     "libs/maia-seed": {
       "name": "@MaiaOS/seed",
-      "version": "26.4.21315-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/logs": "workspace:*",
@@ -93,7 +94,7 @@
     },
     "libs/maia-self": {
       "name": "@MaiaOS/self",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/peer": "workspace:*",
@@ -104,7 +105,7 @@
     },
     "libs/maia-storage": {
       "name": "@MaiaOS/storage",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/logs": "workspace:*",
         "@electric-sql/pglite": "0.4.2",
@@ -115,7 +116,7 @@
     },
     "libs/maia-ucan": {
       "name": "@MaiaOS/maia-ucan",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@noble/ed25519": "3.0.1",
         "@noble/hashes": "2.2.0",
@@ -124,7 +125,7 @@
     },
     "libs/maia-universe": {
       "name": "@MaiaOS/universe",
-      "version": "26.4.21315-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/peer": "workspace:*",
@@ -135,7 +136,7 @@
     },
     "libs/maia-validation": {
       "name": "@MaiaOS/validation",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/logs": "workspace:*",
@@ -146,7 +147,7 @@
     },
     "services/app": {
       "name": "@MaiaOS/app",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/game": "workspace:*",
         "@MaiaOS/logs": "workspace:*",
@@ -163,7 +164,7 @@
     },
     "services/sync": {
       "name": "@MaiaOS/sync",
-      "version": "26.4.21815-next",
+      "version": "26.4.141450-next",
       "dependencies": {
         "@MaiaOS/db": "workspace:*",
         "@MaiaOS/logs": "workspace:*",

--- a/libs/maia-distros/package.json
+++ b/libs/maia-distros/package.json
@@ -11,6 +11,7 @@
 		"output"
 	],
 	"dependencies": {
+		"@electric-sql/pglite": "0.4.2",
 		"@MaiaOS/universe": "workspace:*",
 		"@MaiaOS/db": "workspace:*",
 		"@MaiaOS/runtime": "workspace:*",

--- a/libs/maia-distros/scripts/build.js
+++ b/libs/maia-distros/scripts/build.js
@@ -1,15 +1,27 @@
 #!/usr/bin/env bun
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
 /**
  * Bun-native build for maia-client, sync-server, avens.
  * Uses root jsconfig.json paths for @MaiaOS/* resolution (self-contained bundle).
  */
-import { join, normalize } from 'node:path'
+import { dirname, join, normalize } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const repoRoot = join(__dirname, '../../..')
 const outputDir = join(__dirname, '../output')
+
+function resolvePgliteWasmPath(root) {
+	const fallback = join(root, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
+	try {
+		const require = createRequire(join(root, 'package.json'))
+		const pkgDir = dirname(require.resolve('@electric-sql/pglite/package.json'))
+		return join(pkgDir, 'dist', 'pglite.wasm')
+	} catch {
+		return fallback
+	}
+}
 
 const storageIndexBrowser = join(repoRoot, 'libs/maia-storage/src/index.browser.js')
 const storagePostgresStub = join(repoRoot, 'libs/maia-storage/src/adapters/postgres-stub.js')
@@ -103,11 +115,14 @@ async function main() {
 	// Server runtime is Bun only — sync bundle must use target `bun` (Bun builtins, SQL, etc.).
 	await build('services/sync/src/index.js', 'sync-server.mjs', 'bun')
 
-	const wasmSource = join(repoRoot, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
-	if (existsSync(wasmSource)) {
-		cpSync(wasmSource, join(outputDir, 'pglite.wasm'))
-		console.log('Vendored pglite.wasm')
+	const wasmSource = resolvePgliteWasmPath(repoRoot)
+	const wasmDest = join(outputDir, 'pglite.wasm')
+	if (!existsSync(wasmSource)) {
+		console.error('[maia-distros] Missing pglite.wasm at', wasmSource)
+		process.exit(1)
 	}
+	cpSync(wasmSource, wasmDest)
+	console.log('Vendored pglite.wasm')
 
 	console.log('Distros build complete')
 }

--- a/libs/maia-distros/scripts/build.js
+++ b/libs/maia-distros/scripts/build.js
@@ -1,27 +1,16 @@
 #!/usr/bin/env bun
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
-import { createRequire } from 'node:module'
 /**
  * Bun-native build for maia-client, sync-server, avens.
  * Uses root jsconfig.json paths for @MaiaOS/* resolution (self-contained bundle).
  */
-import { dirname, join, normalize } from 'node:path'
+import { join, normalize } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { resolvePgliteWasmPath } from './resolve-pglite-wasm.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const repoRoot = join(__dirname, '../../..')
 const outputDir = join(__dirname, '../output')
-
-function resolvePgliteWasmPath(root) {
-	const fallback = join(root, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
-	try {
-		const require = createRequire(join(root, 'package.json'))
-		const pkgDir = dirname(require.resolve('@electric-sql/pglite/package.json'))
-		return join(pkgDir, 'dist', 'pglite.wasm')
-	} catch {
-		return fallback
-	}
-}
 
 const storageIndexBrowser = join(repoRoot, 'libs/maia-storage/src/index.browser.js')
 const storagePostgresStub = join(repoRoot, 'libs/maia-storage/src/adapters/postgres-stub.js')

--- a/libs/maia-distros/scripts/resolve-pglite-wasm.js
+++ b/libs/maia-distros/scripts/resolve-pglite-wasm.js
@@ -1,0 +1,47 @@
+/**
+ * Locate pglite.wasm: Node resolution from distros + root, then Bun's node_modules/.bun layout.
+ */
+import { existsSync, readdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+
+function findPgliteWasmInBunStore(root) {
+	const bunRoot = join(root, 'node_modules', '.bun')
+	if (!existsSync(bunRoot)) return null
+	for (const entry of readdirSync(bunRoot)) {
+		if (!entry.includes('electric-sql') || !entry.includes('pglite')) continue
+		const candidate = join(
+			bunRoot,
+			entry,
+			'node_modules',
+			'@electric-sql',
+			'pglite',
+			'dist',
+			'pglite.wasm',
+		)
+		if (existsSync(candidate)) return candidate
+	}
+	return null
+}
+
+export function resolvePgliteWasmPath(root) {
+	const distrosPkg = join(root, 'libs/maia-distros/package.json')
+	const rootPkg = join(root, 'package.json')
+	const wasmSpecifier = '@electric-sql/pglite/dist/pglite.wasm'
+
+	for (const pkgJson of [distrosPkg, rootPkg]) {
+		if (!existsSync(pkgJson)) continue
+		try {
+			const require = createRequire(pkgJson)
+			const p = require.resolve(wasmSpecifier)
+			if (existsSync(p)) return p
+		} catch {
+			/* try next anchor */
+		}
+	}
+
+	const bunHit = findPgliteWasmInBunStore(root)
+	if (bunHit) return bunHit
+
+	return join(root, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
+}

--- a/libs/maia-distros/scripts/vendor-pglite.js
+++ b/libs/maia-distros/scripts/vendor-pglite.js
@@ -4,12 +4,26 @@
  * Adapter passes wasmModule to PGlite.create() so no path resolution needed.
  */
 import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '../../..')
 const outputRoot = join(__dirname, '../output')
-const wasmSource = join(__dirname, '../../../node_modules/@electric-sql/pglite/dist/pglite.wasm')
+
+function resolvePgliteWasmPath(root) {
+	const fallback = join(root, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
+	try {
+		const require = createRequire(join(root, 'package.json'))
+		const pkgDir = dirname(require.resolve('@electric-sql/pglite/package.json'))
+		return join(pkgDir, 'dist', 'pglite.wasm')
+	} catch {
+		return fallback
+	}
+}
+
+const wasmSource = resolvePgliteWasmPath(repoRoot)
 const wasmTarget = join(outputRoot, 'pglite.wasm')
 
 if (!existsSync(wasmSource)) {

--- a/libs/maia-distros/scripts/vendor-pglite.js
+++ b/libs/maia-distros/scripts/vendor-pglite.js
@@ -4,24 +4,13 @@
  * Adapter passes wasmModule to PGlite.create() so no path resolution needed.
  */
 import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
-import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { resolvePgliteWasmPath } from './resolve-pglite-wasm.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '../../..')
 const outputRoot = join(__dirname, '../output')
-
-function resolvePgliteWasmPath(root) {
-	const fallback = join(root, 'node_modules/@electric-sql/pglite/dist/pglite.wasm')
-	try {
-		const require = createRequire(join(root, 'package.json'))
-		const pkgDir = dirname(require.resolve('@electric-sql/pglite/package.json'))
-		return join(pkgDir, 'dist', 'pglite.wasm')
-	} catch {
-		return fallback
-	}
-}
 
 const wasmSource = resolvePgliteWasmPath(repoRoot)
 const wasmTarget = join(outputRoot, 'pglite.wasm')


### PR DESCRIPTION
## Summary

Follow-up to merged PR #54: **sync deploy** failed copying `pglite.wasm` because the flat `node_modules/@electric-sql/pglite/...` path is not always present under Bun’s layout (e.g. Linux/Docker).

## Changes

- Resolve `@electric-sql/pglite` via `require.resolve` from the repo root `package.json`.
- Declare `@electric-sql/pglite` on `@MaiaOS/maia-distros` so the package is install-linked for distros.
- Fail the distros build if `pglite.wasm` is missing (avoids silent Docker COPY failures).

## Verify

- `bun run distros:build` prints `Vendored pglite.wasm` and writes `libs/maia-distros/output/pglite.wasm`.