### PR TITLE
[fix] Bun Postgres SQL max:1 — ERR_POSTGRES_UNSAFE_TRANSACTION on Fly

### DIFF
--- a/libs/maia-storage/src/adapters/postgres.js
+++ b/libs/maia-storage/src/adapters/postgres.js
@@ -391,7 +391,8 @@ export async function createPostgresAdapter(connectionString, blobStore) {
 	}
 
 	const normalized = normalizePostgresConnectionString(connectionString)
-	const sql = new SQL(normalized)
+	// Bun pooled SQL (max > 1) forbids sql.unsafe() outside sql.begin/reserve — this adapter uses unsafe everywhere.
+	const sql = new SQL(normalized, { max: 1 })
 	const db = createSqlDbInterface(sql)
 
 	if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {

--- a/libs/maia-storage/src/clearStorageForReseed.js
+++ b/libs/maia-storage/src/clearStorageForReseed.js
@@ -26,7 +26,7 @@ export async function clearStorageForReseed(options = {}) {
 		if (!databaseUrl) {
 			throw new Error('[clearStorageForReseed] PEER_SYNC_STORAGE=postgres requires PEER_SYNC_DB_URL')
 		}
-		const sql = new SQL(normalizePostgresConnectionString(databaseUrl))
+		const sql = new SQL(normalizePostgresConnectionString(databaseUrl), { max: 1 })
 		try {
 			await sql.unsafe(
 				'TRUNCATE transactions, signatureafter, sessions, covalues, unsynced_covalues, deletedcovalues, schema_version RESTART IDENTITY CASCADE',


### PR DESCRIPTION
Bun's pooled SQL driver (max > 1) disallows `sql.unsafe()` outside `sql.begin`/`reserve`. The CoJSON postgres adapter uses `unsafe` throughout.

Set `{ max: 1 }` on `new SQL(...)` in `libs/maia-storage/src/adapters/postgres.js` and `clearStorageForReseed.js` so production sync no longer throws `PostgresError: Only use sql.begin, sql.reserved or max: 1`, which caused 503s on `/syncRegistry` and failed WebSockets after deploy.