### PR TITLE
[fix] Fly Docker GIT_SHA cache bust; warn-only PEER_SYNC_MODE

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -63,6 +63,7 @@ jobs:
       url: https://sync.next.maia.city/health
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      GITHUB_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -89,6 +90,7 @@ jobs:
       url: https://next.maia.city
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      GITHUB_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 

--- a/libs/FUTURE/maia-knowledge/x.com/security_checklist.md
+++ b/libs/FUTURE/maia-knowledge/x.com/security_checklist.md
@@ -1,0 +1,41 @@
+The SINKING SHIP checklist :
+
+Run this before you ship anything built with AI.
+
+SECURITY
+[ ] No API keys or secrets in frontend code
+[ ] Every route checks authentication (audit all endpoints, not just the obvious ones)
+[ ] HTTPS enforced everywhere, HTTP redirected
+[ ] CORS locked to your domain — not wildcard
+[ ] Input validated and sanitized server-side
+[ ] Rate limiting on auth and sensitive endpoints
+[ ] Passwords hashed with bcrypt or argon2
+[ ] Auth tokens have expiry
+[ ] Sessions invalidated on logout (server-side)
+
+DATABASE
+[ ] Backups configured and tested (test restore, not just backup)
+[ ] Parameterized queries everywhere — no string concatenation
+[ ] Separate dev and production databases
+[ ] Connection pooling configured
+[ ] Migrations in version control, not manual changes
+[ ] App uses a non-root DB user
+
+DEPLOYMENT
+[ ] All environment variables set on the production server
+[ ] SSL certificate installed and valid
+[ ] Firewall configured (only 80/443 public)
+[ ] Process manager running (PM2, systemd)
+[ ] Rollback plan exists
+[ ] Staging test passed before production deploy
+
+CODE
+[ ] No console.logs in production build
+[ ] Error handling on all async operations
+[ ] Loading and error states in UI
+[ ] Pagination on all list endpoints
+[ ] npm audit run, critical issues resolved
+
+Can't check every box? You're not ready to ship.
+
+The post-launch patch costs 10x more than the pre-launch fix.

--- a/services/app/Dockerfile
+++ b/services/app/Dockerfile
@@ -22,8 +22,9 @@ ENV VITE_PEER_APP_HOST=$VITE_PEER_APP_HOST
 
 ENV HUSKY=0
 RUN bun install
-RUN bun run universe:registry
-RUN bun run distros:build
+# GIT_SHA must change per commit so remote BuildKit cannot reuse a stale distros bundle layer
+ARG GIT_SHA=unknown
+RUN echo "GIT_SHA=${GIT_SHA}" && bun run universe:registry && bun run distros:build
 
 # Generate favicons (sync-assets runs inside build.js, outputs to dist/brand)
 RUN bun scripts/generate-favicons.js

--- a/services/app/deploy.sh
+++ b/services/app/deploy.sh
@@ -31,7 +31,9 @@ retry_flyctl_deploy() {
       --app "$app_name" \
       --wait-timeout 600 \
       --build-arg VITE_PEER_SYNC_HOST="${VITE_PEER_SYNC_HOST}" \
-      --build-arg VITE_PEER_APP_HOST=next.maia.city 2>&1 | tee /tmp/flyctl-deploy.log
+      --build-arg VITE_PEER_APP_HOST=next.maia.city \
+      --build-arg "GIT_SHA=${GITHUB_SHA:-$(git -C "$MONOREPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}" \
+      2>&1 | tee /tmp/flyctl-deploy.log
     
     local deploy_exit_code=${PIPESTATUS[0]}
     

--- a/services/sync/Dockerfile
+++ b/services/sync/Dockerfile
@@ -16,8 +16,9 @@ COPY scripts ./scripts
 
 ENV HUSKY=0
 RUN bun install
-RUN bun run universe:registry
-RUN bun run distros:build
+# GIT_SHA must change per commit so remote BuildKit cannot reuse a stale distros bundle layer
+ARG GIT_SHA=unknown
+RUN echo "GIT_SHA=${GIT_SHA}" && bun run universe:registry && bun run distros:build
 
 # Runtime stage - single sync-server.mjs bundle + vendored pglite.wasm (no node_modules)
 FROM oven/bun:1-slim

--- a/services/sync/deploy.sh
+++ b/services/sync/deploy.sh
@@ -25,7 +25,9 @@ retry_flyctl_deploy() {
       --app "$app_name" \
       --wait-timeout 600 \
       --auto-confirm \
-      --ha=false 2>&1 | tee /tmp/flyctl-deploy.log
+      --ha=false \
+      --build-arg "GIT_SHA=${GITHUB_SHA:-$(git -C "$MONOREPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}" \
+      2>&1 | tee /tmp/flyctl-deploy.log
 
     local deploy_exit_code=${PIPESTATUS[0]}
 

--- a/services/sync/src/index.js
+++ b/services/sync/src/index.js
@@ -11,7 +11,7 @@
  *     - pglite: PEER_DB_PATH (default ./pg-lite.db)
  *     - postgres: PEER_SYNC_DB_URL (required)
  *   AVEN_MAIA_GUARDIAN: Human account co-id (co_z...). If set, add as admin of °maia spark guardian; also seeds /sync/write so that account can sync without POST /register.
- *   Seeding: auto-detect empty DB via SQL (no rows in CoJSON data tables → genesis seed); registry migrate every boot. No PEER_SYNC_MODE (obsolete — remove from env).
+ *   Seeding: auto-detect empty DB via SQL (no rows in CoJSON data tables → genesis seed); registry migrate every boot. PEER_SYNC_MODE is ignored if set (obsolete — remove from Fly when convenient).
  *   SEED_VIBES: Default "all". Which vibes to seed (todos, chat, quickjs, etc). "all" seeds every vibe including quickjs.
  *   Dev: when NODE_ENV is not production, sync watches `.maia` under maia-universe and live-migrates after registry regen. Production (Fly) sets NODE_ENV=production, so watch is off.
  *   PEER_APP_HOST: Allowed CORS origin (e.g. https://next.maia.city). When set, only that origin can call sync/LLM in production. Unset = * (dev).
@@ -73,8 +73,8 @@ const RED_PILL_API_KEY = process.env.RED_PILL_API_KEY || ''
 
 const avenMaiaGuardian = process.env.AVEN_MAIA_GUARDIAN?.trim() || null
 if ((process.env.PEER_SYNC_MODE ?? '').trim() !== '') {
-	throw new Error(
-		`${OPS_PREFIX.sync} PEER_SYNC_MODE is obsolete — remove it from .env and Fly secrets. To reseed: wipe Postgres/PGlite/Tigris data manually, then restart sync.`,
+	opsSync.warn(
+		'PEER_SYNC_MODE is set but ignored (obsolete). Remove from Fly secrets / .env when convenient — reseed by wiping Postgres/PGlite/Tigris data manually.',
 	)
 }
 const maiaDevMigrateWatch = process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
This pull request addresses two deployment issues.

**Fly / Docker:** Remote BuildKit was reusing a cached `distros:build` layer, so production could ship an older bundle than the merged commit. App and sync Dockerfiles now take a `GIT_SHA` build arg and fold it into the distros `RUN`; deploy scripts pass `GITHUB_SHA` from CI (or local `git rev-parse HEAD`). The Next workflow exports `GITHUB_SHA` for both deploy jobs.

**Sync:** If `PEER_SYNC_MODE` is still set in Fly secrets or `.env`, sync logs a warning instead of exiting, so stale secrets do not crash the process. The variable remains obsolete and should be removed when convenient.

Also includes a small security checklist note under `libs/FUTURE/maia-knowledge/`.